### PR TITLE
Grammar type specifiers

### DIFF
--- a/com.minres.coredsl.tests/inputs/fir.core_desc
+++ b/com.minres.coredsl.tests/inputs/fir.core_desc
@@ -2,7 +2,7 @@ import "inputs/isa_1.core_desc"
 
 InstructionSet X_FIR_1 extends RV32I {
 	architectural_state {
-		unsigned N_ACC = 4;
+		unsigned int N_ACC = 4;
 		int ACC[N_ACC];
 	}
 	instructions {
@@ -36,10 +36,10 @@ InstructionSet X_FIR_1 extends RV32I {
 			encoding: acc[6:0] :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0010111;
 			behavior: {
 				if (acc < N_ACC) {
-					int<32> lhs = X[rs1];
-					int<32> rhs = X[rs2];
-					int<32> lane1 = lhs[31:16] * rhs[31:16];
-					int<32> lane2 = lhs[15:0] * rhs[15:0];
+					signed<32> lhs = X[rs1];
+					signed<32> rhs = X[rs2];
+					signed<32> lane1 = lhs[31:16] * rhs[31:16];
+					signed<32> lane2 = lhs[15:0] * rhs[15:0];
 					ACC[acc] += lane1 + lane2;
 				}
 			}

--- a/com.minres.coredsl.tests/inputs/isa_1.core_desc
+++ b/com.minres.coredsl.tests/inputs/isa_1.core_desc
@@ -1,12 +1,12 @@
 InstructionSet RV32I {
     architectural_state {
         unsigned int XLEN, FLEN;
-        unsigned CSR_SIZE = 4096;
-        unsigned REG_FILE_SIZE=32;
+        unsigned int CSR_SIZE = 4096;
+        unsigned int REG_FILE_SIZE=32;
     	[[is_pc]] int PC ;
         int X[REG_FILE_SIZE];
         extern char MEM[1<<XLEN];
-        extern unsigned CSR[CSR_SIZE];
+        extern unsigned int CSR[CSR_SIZE];
     }
     instructions { 
        ADDI {
@@ -37,8 +37,8 @@ InstructionSet RV32I {
         JAL[[no_cont]] {
             encoding:imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 0b1101111;
             behavior: {
-                if(rd!=0) X[rd] = (unsigned)PC;
-                PC = PC+(signed)imm;
+                if(rd!=0) X[rd] = (unsigned int)PC;
+                PC = PC+(signed int)imm;
             }
         }
     }

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslAttributeValidationTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslAttributeValidationTest.xtend
@@ -42,7 +42,7 @@ class CoreDslAttributeValidationTest {
 		val content = '''
 			InstructionSet AttributeValidationTestInstructionSet {
 			    architectural_state {
-			        unsigned XLEN;
+			        unsigned int XLEN;
 			        unsigned<XLEN> field «declAttribString»;
 			    }
 			    functions {
@@ -81,7 +81,7 @@ class CoreDslAttributeValidationTest {
 		val content = '''
 			InstructionSet AttributeValidationTestInstructionSet {
 			    architectural_state {
-			        unsigned XLEN;
+			        unsigned int XLEN;
 			        unsigned<XLEN> field «attribString»;
 			    }
 			    functions {
@@ -131,8 +131,8 @@ class CoreDslAttributeValidationTest {
 		val content = '''
 			InstructionSet AttributeValidationTestInstructionSet {
 			    architectural_state {
-			        unsigned XLEN;
-			        unsigned<XLEN> field «declAttribString»;
+			        unsigned int XLEN;
+					unsigned<XLEN> field «declAttribString»;
 			    }
 			    functions {
 			    	void fun() «funcAttribString» {}

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslCoreScopingTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslCoreScopingTest.xtend
@@ -27,7 +27,7 @@ class CoreDslCoreScopingTest {
         val content = '''
         InstructionSet BaseISA {
             architectural_state {
-                unsigned X[32];
+                unsigned int X[32];
             }
         }
         

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslISAScopingTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslISAScopingTest.xtend
@@ -116,7 +116,7 @@ class CoreDslISAScopingTest {
             InstructionSet TestISA {
             architectural_state {
                 int CCC = 42;
-                unsigned X[32];
+                unsigned int X[32];
             }
 
             functions {
@@ -146,7 +146,7 @@ class CoreDslISAScopingTest {
         InstructionSet TestISA {
             architectural_state {
                 int CCC = 42;
-                unsigned X[32];
+                unsigned int X[32];
             }
 
             functions {
@@ -205,7 +205,7 @@ class CoreDslISAScopingTest {
         InstructionSet TestISA {
             architectural_state {
                 struct {
-                    unsigned x, y;
+                    unsigned int X, y;
                 } point;
             }
             
@@ -229,7 +229,7 @@ class CoreDslISAScopingTest {
         InstructionSet TestISA {
             architectural_state {
                 struct point_s {
-                    unsigned x, y;
+                    unsigned int X, y;
                 };
             }
             
@@ -282,7 +282,7 @@ class CoreDslISAScopingTest {
             architectural_state {
                 unsigned N_REGS = 4;
                 struct point_s {
-                    unsigned x, y;
+                    unsigned int X, y;
                 };
             }
             
@@ -309,10 +309,10 @@ class CoreDslISAScopingTest {
             architectural_state {
                 struct rect_s {
                     struct origin_s {
-                        unsigned x, y;
+                        unsigned int X, y;
                     } origin;
                     struct size_s {
-                        unsigned x, y;
+                        unsigned int X, y;
                     } size;
                 } rect;
             }

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
@@ -60,7 +60,7 @@ class CoreDslTerminalsTest {
     @Test
     def void parseIntLiterals() {
         val content = addBehaviorContext('''
-            unsigned c;
+            unsigned int c;
             unsigned<6> v;
             // C syntax
             c = 42;
@@ -87,55 +87,10 @@ class CoreDslTerminalsTest {
     }
 
     @Test
-    def void parseIntLiteralSuffixes() {
-        val content = addBehaviorContext('''
-            unsigned u32;
-            unsigned long u64;
-            unsigned long long u128;
-            long i64;
-            long long i128;
-            u32 = 42u;
-            u32 = 42U;
-            
-            i64 = 42l;
-            i64 = 42L;
-            i128 = 42ll;
-            i128 = 42LL;
-            
-            u64 = 42ul;
-            u128 = 42ull;
-            // u64 = 42lu;  // currently not supported
-            // u128 = 42llu; // ditto
-         	''').parse
-        validator.assertNoErrors(content)
-
-        val compound = ((content.definitions.get(0) as InstructionSet).instructions.get(0).behavior as CompoundStatement)
-        for (el : compound.items.subList(3, compound.items.size())) {
-            if (el instanceof ExpressionStatement) {
-                val expr = el.expr.expressions.get(0) as AssignmentExpression
-                // val lhsName = (expr.left as PrimaryExpression).ref.name;
-                val rhs = (expr.assignments.get(0).right as PrimaryExpression).constant as IntegerConstant
-                val intValue = rhs.value.intValue
-                assertEquals(intValue, 42)
-            // FIXME: cannot check size and signedness, because the BigIntegerWithRadix class is not accessible here -- why?
-            }
-        }
-
-        assertIssues("int i = 6'd42u;") // Verilog syntax cannot have the suffix
-        assertIssues("int i = 6'd42ul;")
-        assertIssues("int i = 42uu;")
-        assertIssues("int i = 42lul;")
-        assertIssues("int i = 42ulu;")
-//		assertIssues("int i = 42lL;") // TODO: The INTEGERValueConverter currently does not handle this case -- does it matter?
-        assertIssues("int i = 42lll;")
-    }
-
-    @Test
     def void parseFloatLiterals() {
         val content = addBehaviorContext('''
             double d, d1, d0;
             float f;
-            long double ld;
             
             d = 3.14;
             d = 0.314e1;
@@ -147,8 +102,6 @@ class CoreDslTerminalsTest {
             
             f = 3.14f;
             f = 3.14F;
-            ld = 3.14l;
-            ld = 3.14L;
         ''').parse
         validator.assertNoErrors(content)
 
@@ -159,7 +112,7 @@ class CoreDslTerminalsTest {
                 val lhsName = ((expr.left as PrimaryExpression).ref as DirectDeclarator).name;
                 val rhs = (expr.assignments.get(0).right as PrimaryExpression).constant as FloatingConstant
                 val floatValue = rhs.value.doubleValue
-                if (lhsName == "d" || lhsName == "f" || lhsName == "ld")
+                if (lhsName == "d" || lhsName == "f")
                     assertTrue(Math.abs(floatValue - 3.14) < 1e-6)
                 else if (lhsName == "d1")
                     assertTrue(floatValue == 1.0)

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
@@ -32,7 +32,7 @@ class CoreDslTypeTest {
         val content = '''
         InstructionSet TestISA {
             architectural_state {
-                unsigned XLEN;
+                unsigned int XLEN;
                 unsigned<XLEN>  X[32];
             }
         }

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -162,34 +162,39 @@ fragment DeclarationSpecifier
 Attribute
     :  	DoubleLeftBracket type=ID ('=' params+=ConditionalExpression | '(' params+=ConditionalExpression (',' params+=ConditionalExpression)* ')')? DoubleRightBracket
     ;
-    
+
 TypeSpecifier
-	:	PrimitiveType 
-	|	CompositeType
-	|	EnumType
-	;
-    
-PrimitiveType
-	:	dataType+=DataTypes+ BitSizeSpecifier? 
+	:	ValueTypeSpecifier
+	|	VoidTypeSpecifier
 	;
 
-fragment BitSizeSpecifier
-	:	'<' size+=PrimaryExpression (',' size+=PrimaryExpression ',' size+=PrimaryExpression ',' size+=PrimaryExpression)? '>'
+ValueTypeSpecifier
+	:	PrimitiveTypeSpecifier
+	|	CompositeTypeSpecifier
+	|	EnumTypeSpecifier
 	;
 
-EnumType
-    :   'enum' name=ID? '{' EnumeratorList ','? '}'
-    |   'enum' name=ID
-    ;
+PrimitiveTypeSpecifier
+	:	IntegerTypeSpecifier
+	|	FloatTypeSpecifier
+	|	BoolTypeSpecifier
+	;
 
-fragment EnumeratorList:   enumerators+=Enumerator (',' enumerators+=Enumerator)*;
+IntegerTypeSpecifier
+	:	signedness=IntegerSignedness (shorthand=IntegerSizeShorthand | '<' size=PrimaryExpression '>')
+	|	shorthand=IntegerSizeShorthand
+	;
 
-Enumerator
-    :   name=ID
-    |   name=ID '=' expression=ConstantExpression
-    ;
+FloatTypeSpecifier
+	:	shorthand=FloatSizeShorthand;
 
-CompositeType
+BoolTypeSpecifier
+	:	{BoolTypeSpecifier} 'bool';
+
+VoidTypeSpecifier
+	:	{VoidTypeSpecifier} 'void';
+
+CompositeTypeSpecifier
     :   composeType=StructOrUnion name=ID? '{' (declaration += StructDeclaration)* '}'
     |   composeType=StructOrUnion name=ID
     ;
@@ -201,6 +206,17 @@ StructDeclaration
 StructDeclarationSpecifier
     :   type=TypeSpecifier
     |   qualifiers+=TypeQualifier
+    ;
+	
+// TODO add optional size specifier after name? (':' size=IntegerTypeSpecifier)?
+EnumTypeSpecifier
+    :   'enum' name=ID? '{' enumerators+=EnumMemberDeclaration (',' enumerators+=EnumMemberDeclaration)* ','? '}'
+    |   'enum' name=ID
+    ;
+
+EnumMemberDeclaration
+    :   name=ID
+    |   name=ID '=' expression=ConstantExpression
     ;
 
 InitDeclarator
@@ -377,12 +393,11 @@ DoubleRightBracket hidden(WS, ML_COMMENT, SL_COMMENT): RIGHT_BR RIGHT_BR;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-enum DataTypes
-	: 	BOOL='bool' | CHAR='char' | SHORT='short' | INT='int' | LONG='long'
-	| 	SIGNED='signed' | UNSIGNED='unsigned'
-	|	FLOAT='float'	| DOUBLE='double' | VOID='void'
-	|	ALIAS='alias'
-	;
+enum IntegerSignedness : SIGNED='signed' | UNSIGNED='unsigned';
+
+enum IntegerSizeShorthand : CHAR='char' | SHORT='short' | INT='int' | LONG='long';
+
+enum FloatSizeShorthand : FLOAT='float' | DOUBLE='double';
 
 enum TypeQualifier: CONST='const' | VOLATILE='volatile';
 

--- a/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
@@ -5,7 +5,7 @@ package com.minres.coredsl.scoping
 
 import com.minres.coredsl.coreDsl.BitField
 import com.minres.coredsl.coreDsl.BlockItem
-import com.minres.coredsl.coreDsl.CompositeType
+import com.minres.coredsl.coreDsl.CompositeTypeSpecifier
 import com.minres.coredsl.coreDsl.CompoundStatement
 import com.minres.coredsl.coreDsl.CoreDef
 import com.minres.coredsl.coreDsl.CoreDslPackage
@@ -203,12 +203,12 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
         decl.init.map[it.declarator]
     }
 
-    def dispatch Iterable<DirectDeclarator> directDeclarations(CompositeType spec) {
+    def dispatch Iterable<DirectDeclarator> directDeclarations(CompositeTypeSpecifier spec) {
         if (spec.declaration.size > 0)
             spec.declaration.directDeclarations
         else {
             val specifier = spec.eContainer.findCompositeType([
-                CompositeType d|d.name!==null?d.name==spec.name:false
+                CompositeTypeSpecifier d|d.name!==null?d.name==spec.name:false
             ])
             specifier===null?#[]:specifier.declaration.directDeclarations
         }
@@ -224,24 +224,24 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
     /************************************************************************
      * type extension methods begin
      */
-    def dispatch CompositeType findCompositeType(Declaration object, (CompositeType)=>boolean predicate){
+    def dispatch CompositeTypeSpecifier findCompositeType(Declaration object, (CompositeTypeSpecifier)=>boolean predicate){
         val res = object.eContainer.declarationsBefore(object)
             .map[it.type]
-            .filter[it instanceof CompositeType]
-            .map[it as CompositeType]
+            .filter[it instanceof CompositeTypeSpecifier]
+            .map[it as CompositeTypeSpecifier]
             .findFirst(predicate)
         res ?: object.eContainer.eContainer.findCompositeType(predicate)
     }
         
-    def dispatch CompositeType findCompositeType(ISA isa, (CompositeType)=>boolean predicate){
+    def dispatch CompositeTypeSpecifier findCompositeType(ISA isa, (CompositeTypeSpecifier)=>boolean predicate){
         isa.allDeclarations
             .map[it.type]
-            .filter[it instanceof CompositeType]
-            .map[it as CompositeType]
+            .filter[it instanceof CompositeTypeSpecifier]
+            .map[it as CompositeTypeSpecifier]
             .findFirst(predicate)
     }
 
-    def dispatch CompositeType findCompositeType(EObject object, (CompositeType)=>boolean predicate){
+    def dispatch CompositeTypeSpecifier findCompositeType(EObject object, (CompositeTypeSpecifier)=>boolean predicate){
         object.eContainer.findCompositeType(predicate)
     }
     /*

--- a/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
@@ -6,7 +6,6 @@ import com.minres.coredsl.coreDsl.Attribute
 import com.minres.coredsl.coreDsl.BitField
 import com.minres.coredsl.coreDsl.BitValue
 import com.minres.coredsl.coreDsl.BoolConstant
-import com.minres.coredsl.coreDsl.CompositeType
 import com.minres.coredsl.coreDsl.CompoundStatement
 import com.minres.coredsl.coreDsl.CoreDef
 import com.minres.coredsl.coreDsl.Declaration
@@ -35,7 +34,6 @@ import com.minres.coredsl.coreDsl.ParameterList
 import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
 import com.minres.coredsl.coreDsl.PrimaryExpression
-import com.minres.coredsl.coreDsl.PrimitiveType
 import com.minres.coredsl.coreDsl.SpawnStatement
 import com.minres.coredsl.coreDsl.StringLiteral
 import com.minres.coredsl.coreDsl.StructDeclaration
@@ -59,6 +57,12 @@ import org.eclipse.emf.ecore.EObject
 import com.minres.coredsl.coreDsl.FunctionCallExpression
 import com.minres.coredsl.coreDsl.ArrayAccessExpression
 import com.minres.coredsl.coreDsl.MemberAccessExpression
+import com.minres.coredsl.coreDsl.CompositeTypeSpecifier
+import com.minres.coredsl.coreDsl.EnumTypeSpecifier
+import com.minres.coredsl.coreDsl.BoolTypeSpecifier
+import com.minres.coredsl.coreDsl.VoidTypeSpecifier
+import com.minres.coredsl.coreDsl.FloatTypeSpecifier
+import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
 
 class Visualizer {
 	
@@ -357,22 +361,39 @@ class Visualizer {
 		);
 	}
 	
-	private def dispatch VisualNode genNode(PrimitiveType node) {
-		return node.dataType.size == 1
-		? makeNode(node, "Primitive Type",
-			makeNamedLiteral("Data Type", node.dataType.get(0).toString),
-			makeGroup("Bit Size", node.size)
-		)
-		: makeNode(node, "Primitive Type",
-			makePortGroup("Data Type", node.dataType.map[type | makeImmediateLiteral(type.toString)]),
-			makeGroup("Bit Size", node.size)
+	private def dispatch VisualNode genNode(VoidTypeSpecifier node) {
+		return makeNode(node, "Void Type");
+	}
+	
+	private def dispatch VisualNode genNode(BoolTypeSpecifier node) {
+		return makeNode(node, "Bool Type");
+	}
+	
+	private def dispatch VisualNode genNode(FloatTypeSpecifier node) {
+		return makeNode(node, "Float Type",
+			makeNamedLiteral("Shorthand", node.shorthand?.literal)
 		);
 	}
 	
-	private def dispatch VisualNode genNode(CompositeType node) {
+	private def dispatch VisualNode genNode(IntegerTypeSpecifier node) {
+		return makeNode(node, "Integer Type",
+			makeNamedLiteral("Signedness", node.signedness?.literal),
+			makeNamedLiteral("Shorthand", node.shorthand?.literal),
+			makeChild("Bit Size", node.size)
+		);
+	}
+	
+	private def dispatch VisualNode genNode(CompositeTypeSpecifier node) {
 		return makeNode(node, node.composeType == StructOrUnion.STRUCT ? "Struct Type" : "Union Type",
 			makeNamedLiteral("Name", node.name),
 			makeGroup("Declarations", node.declaration)
+		)
+	}
+	
+	private def dispatch VisualNode genNode(EnumTypeSpecifier node) {
+		return makeNode(node, "Enum Type",
+			makeNamedLiteral("Name", node.name),
+			makeGroup("Members", node.enumerators)
 		)
 	}
 	

--- a/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
@@ -6,12 +6,11 @@ import com.minres.coredsl.coreDsl.BitValue
 import com.minres.coredsl.coreDsl.BoolConstant
 import com.minres.coredsl.coreDsl.CastExpression
 import com.minres.coredsl.coreDsl.CharacterConstant
-import com.minres.coredsl.coreDsl.CompositeType
+import com.minres.coredsl.coreDsl.CompositeTypeSpecifier
 import com.minres.coredsl.coreDsl.ConditionalExpression
-import com.minres.coredsl.coreDsl.DataTypes
 import com.minres.coredsl.coreDsl.Declaration
 import com.minres.coredsl.coreDsl.DirectDeclarator
-import com.minres.coredsl.coreDsl.EnumType
+import com.minres.coredsl.coreDsl.EnumTypeSpecifier
 import com.minres.coredsl.coreDsl.Expression
 import com.minres.coredsl.coreDsl.FloatingConstant
 import com.minres.coredsl.coreDsl.FunctionDefinition
@@ -21,7 +20,6 @@ import com.minres.coredsl.coreDsl.IntegerConstant
 import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
 import com.minres.coredsl.coreDsl.PrimaryExpression
-import com.minres.coredsl.coreDsl.PrimitiveType
 import com.minres.coredsl.coreDsl.StringLiteral
 import com.minres.coredsl.coreDsl.Encoding
 import com.minres.coredsl.coreDsl.Field
@@ -39,6 +37,12 @@ import java.math.BigInteger
 import com.minres.coredsl.coreDsl.FunctionCallExpression
 import com.minres.coredsl.coreDsl.MemberAccessExpression
 import com.minres.coredsl.coreDsl.ArrayAccessExpression
+import com.minres.coredsl.coreDsl.VoidTypeSpecifier
+import com.minres.coredsl.coreDsl.FloatTypeSpecifier
+import com.minres.coredsl.coreDsl.FloatSizeShorthand
+import com.minres.coredsl.coreDsl.BoolTypeSpecifier
+import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
+import com.minres.coredsl.coreDsl.IntegerSignedness
 
 class TypeProvider {
 
@@ -72,55 +76,64 @@ class TypeProvider {
         e.typeFor(e.parentOfType(ISA))
     }
 
-    def static dispatch DataType typeFor(CompositeType e, ISA ctx) {
+    def static dispatch DataType typeFor(CompositeTypeSpecifier e, ISA ctx) {
         return new DataType(DataType.Type.COMPOSITE, 0)
     }
 
-    def static dispatch DataType typeFor(EnumType e, ISA ctx) {
+    def static dispatch DataType typeFor(EnumTypeSpecifier e, ISA ctx) {
         return new DataType(DataType.Type.INTEGRAL_SIGNED, 32)
     }
+    
+    def static dispatch DataType typeFor(VoidTypeSpecifier e, ISA ctx) {
+		return new DataType(DataType.Type.VOID, 0)    	
+    }
+    
+    def static dispatch DataType typeFor(FloatTypeSpecifier e, ISA ctx) {
+    	if(e.shorthand == FloatSizeShorthand.DOUBLE)
+    		return new DataType(DataType.Type.FLOAT, 64)
+    	return new DataType(DataType.Type.FLOAT, 32) 
+    }
+    
+    def static dispatch DataType typeFor(BoolTypeSpecifier e, ISA ctx) {
+    	return new DataType(DataType.Type.INTEGRAL_SIGNED, 1) 
+    }
 
-    def static dispatch DataType typeFor(PrimitiveType e, ISA ctx) {
-        if (e.dataType.findFirst[it == DataTypes.VOID] !== null)
-            return new DataType(DataType.Type.VOID, 0)
-        if (e.dataType.findFirst[it == DataTypes.FLOAT] !== null)
-            return new DataType(DataType.Type.FLOAT, 32)
-        val longCount = e.dataType.filter[it === DataTypes.LONG].size
-        if (e.dataType.findFirst[it === DataTypes.DOUBLE] !== null)
-            return longCount == 1 ? new DataType(DataType.Type.FLOAT, 80) : new DataType(DataType.Type.FLOAT, 64)
-        if (e.dataType.findFirst[it === DataTypes.BOOL] !== null)
-            return new DataType(DataType.Type.INTEGRAL_SIGNED, 1)
-        val isUnsigned = e.dataType.findFirst[it === DataTypes.UNSIGNED] !== null
-        if (e.size.size > 0) {
-            val sizeValue = e.size.get(0).valueFor(EvaluationContext.root(ctx))
+    def static dispatch DataType typeFor(IntegerTypeSpecifier e, ISA ctx) {
+        val isUnsigned = e.signedness == IntegerSignedness.UNSIGNED;
+        
+        if (e.size !== null) {
+            val sizeValue = e.size.valueFor(EvaluationContext.root(ctx))
             if(sizeValue === null || !(sizeValue.value instanceof BigInteger)) return null
             val sizeInt = (sizeValue.value as BigInteger).intValue
             return isUnsigned
                 ? new DataType(DataType.Type.INTEGRAL_UNSIGNED, sizeInt)
                 : new DataType(DataType.Type.INTEGRAL_SIGNED, sizeInt)
         } else {
-            if (longCount == 2)
-                return isUnsigned
-                    ? new DataType(DataType.Type.INTEGRAL_UNSIGNED, 128)
-                    : new DataType(DataType.Type.INTEGRAL_SIGNED, 128)
-            else if (longCount == 1)
-                return isUnsigned
-                    ? new DataType(DataType.Type.INTEGRAL_UNSIGNED, 128)
-                    : new DataType(DataType.Type.INTEGRAL_SIGNED, 128)
-            else if (longCount == 0) {
-                if (e.dataType.findFirst[it === DataTypes.SHORT] !== null)
-                    return isUnsigned
-                        ? new DataType(DataType.Type.INTEGRAL_UNSIGNED, 16)
-                        : new DataType(DataType.Type.INTEGRAL_SIGNED, 16)
-                if (e.dataType.findFirst[it === DataTypes.CHAR] !== null)
+			switch(e.shorthand) {
+				case CHAR: {
                     return isUnsigned
                         ? new DataType(DataType.Type.INTEGRAL_UNSIGNED, 8)
                         : new DataType(DataType.Type.INTEGRAL_SIGNED, 8)
-                return isUnsigned
-                    ? new DataType(DataType.Type.INTEGRAL_UNSIGNED, 32)
-                    : new DataType(DataType.Type.INTEGRAL_SIGNED, 32)
-            }
+				}
+				case SHORT: {
+                    return isUnsigned
+                        ? new DataType(DataType.Type.INTEGRAL_UNSIGNED, 16)
+                        : new DataType(DataType.Type.INTEGRAL_SIGNED, 16)
+				}
+				case INT: {
+                	return isUnsigned
+                    	? new DataType(DataType.Type.INTEGRAL_UNSIGNED, 32)
+                    	: new DataType(DataType.Type.INTEGRAL_SIGNED, 32)
+				}
+				case LONG: {
+                	return isUnsigned
+	                    ? new DataType(DataType.Type.INTEGRAL_UNSIGNED, 64)
+                    	: new DataType(DataType.Type.INTEGRAL_SIGNED, 64)
+				}
+			}
         }
+        
+        return null;
     }
 
     def dispatch static DataType typeFor(Expression e, ISA ctx) {
@@ -270,8 +283,7 @@ class TypeProvider {
     
     def static boolean isComparable(DataType left, DataType right){
         if (left.size > 0 && right.size > 0) {
-            if ((left.type == DataTypes.FLOAT || left.type == DataTypes.DOUBLE) &&
-                (right.type == DataTypes.FLOAT || right.type == DataTypes.DOUBLE))
+            if (left.type == DataType.Type.FLOAT && right.type == DataType.Type.FLOAT)
                 return true
             if (left.type == right.type)
                 return true
@@ -284,8 +296,7 @@ class TypeProvider {
             if (to.type == from.type && to.size == from.size)
                 return true
             if (to.size > 0 && from.size > 0) {
-                if ((to.type == DataTypes.FLOAT || to.type == DataTypes.DOUBLE) &&
-                    (from.type == DataTypes.FLOAT || from.type == DataTypes.DOUBLE))
+                if (to.type == DataType.Type.FLOAT && from.type == DataType.Type.FLOAT)
                     return true
                 if (to.isIntegral && from.isIntegral)
                     return (to.type == from.type) || (to.size == from.size)

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/CoreDslValidator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/CoreDslValidator.xtend
@@ -10,9 +10,6 @@ import com.minres.coredsl.coreDsl.InfixExpression
 import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
 import com.minres.coredsl.coreDsl.PrimaryExpression
-import com.minres.coredsl.coreDsl.PrimitiveType
-import com.minres.coredsl.coreDsl.TypeSpecifier
-import com.minres.coredsl.typing.DataType
 
 import static extension com.minres.coredsl.typing.TypeProvider.*
 import org.eclipse.xtext.validation.Check
@@ -107,24 +104,6 @@ class CoreDslValidator extends AbstractCoreDslValidator {
 //            }
 //            case AssignmentExpression: {
 //            }
-		}
-	}
-
-	// @Check
-	def checkType(TypeSpecifier e) {
-		switch (e) {
-//            case CompositeType: {
-//            }
-//            case EnumType: {
-//            }
-			case PrimitiveType: {
-				if (e.typeFor === new DataType(DataType.Type.COMPOSITE, 0))
-					error(
-						"incompatible types used",
-						CoreDslPackage.Literals.PRIMITIVE_TYPE__DATA_TYPE,
-						TYPE_MISMATCH
-					)
-			}
 		}
 	}
 	


### PR DESCRIPTION
Depends on #17 

This PR rewrites the grammar for type specifiers and introduces a proper hierarchy.
Nonsense types like `unsigned float<17>` or `double char char` are no longer syntactically valid.

previous hierarchy:
```
TypeSpecifier
    PrimitiveType
    CompositeType
    EnumType
```

new hierarchy:
```
TypeSpecifier
    ValueTypeSpecifier
        PrimitiveTypeSpecifier
            IntegerTypeSpecifier
            FloatTypeSpecifier
            BoolTypeSpecifier
        CompositeTypeSpecifier
        EnumTypeSpecifier
    VoidTypeSpecifier
```