### PR TITLE
PrimaryExpression grammar rules

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
@@ -9,10 +9,8 @@ import com.minres.coredsl.coreDsl.CompoundStatement
 import com.minres.coredsl.coreDsl.DescriptionContent
 import com.minres.coredsl.coreDsl.DirectDeclarator
 import com.minres.coredsl.coreDsl.ExpressionStatement
-import com.minres.coredsl.coreDsl.FloatingConstant
 import com.minres.coredsl.coreDsl.InstructionSet
 import com.minres.coredsl.coreDsl.IntegerConstant
-import com.minres.coredsl.coreDsl.PrimaryExpression
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.extensions.InjectionExtension
 import org.eclipse.xtext.testing.util.ParseHelper
@@ -23,6 +21,8 @@ import org.junit.jupiter.api.^extension.ExtendWith
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertTrue
+import com.minres.coredsl.coreDsl.FloatConstant
+import com.minres.coredsl.coreDsl.IdentifierReference
 
 @ExtendWith(InjectionExtension)
 @InjectWith(CoreDslInjectorProvider)
@@ -80,7 +80,7 @@ class CoreDslTerminalsTest {
         for (el : compound.items) {
             if (el instanceof ExpressionStatement) {
                 val expr = el.expr.expressions.get(0) as AssignmentExpression
-                val rhs = (expr.assignments.get(0).right as PrimaryExpression).constant as IntegerConstant
+                val rhs = expr.assignments.get(0).right as IntegerConstant
                 assertEquals(rhs.value.intValue, 42)
             }
         }
@@ -109,8 +109,8 @@ class CoreDslTerminalsTest {
         for (el : compound.items.subList(3, compound.items.size())) {
             if (el instanceof ExpressionStatement) {
                 val expr = el.expr.expressions.get(0) as AssignmentExpression
-                val lhsName = ((expr.left as PrimaryExpression).ref as DirectDeclarator).name;
-                val rhs = (expr.assignments.get(0).right as PrimaryExpression).constant as FloatingConstant
+                val lhsName = ((expr.left as IdentifierReference).identifier as DirectDeclarator).name;
+                val rhs = expr.assignments.get(0).right as FloatConstant
                 val floatValue = rhs.value.doubleValue
                 if (lhsName == "d" || lhsName == "f")
                     assertTrue(Math.abs(floatValue - 3.14) < 1e-6)

--- a/com.minres.coredsl.ui/src/com/minres/coredsl/ui/outline/CoreDslOutlineTreeProvider.xtend
+++ b/com.minres.coredsl.ui/src/com/minres/coredsl/ui/outline/CoreDslOutlineTreeProvider.xtend
@@ -10,7 +10,7 @@ import com.minres.coredsl.coreDsl.Encoding
 import com.minres.coredsl.coreDsl.Instruction
 import com.minres.coredsl.coreDsl.InstructionSet
 import com.minres.coredsl.coreDsl.Statement
-import com.minres.coredsl.coreDsl.Variable
+import com.minres.coredsl.coreDsl.Identifier
 import org.eclipse.xtext.ui.editor.outline.IOutlineNode
 import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider
 import org.eclipse.xtext.ui.editor.outline.impl.DocumentRootNode
@@ -65,7 +65,7 @@ class CoreDslOutlineTreeProvider extends DefaultOutlineTreeProvider {
 		createNode(parentNode, stmt.behavior)
 	}
 
-	def boolean _isLeaf(Variable variable) {
+	def boolean _isLeaf(Identifier variable) {
 		return true;
 	}
 

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -342,49 +342,32 @@ PostfixExpression:
 	|	{PostfixExpression.left=current} op='--'
 	)*;
 
-PrimaryExpression
-    :	ref=[Variable]
-    |   constant=Constant
-    |   literal+=StringLiteral+
-    |   '(' left=ConditionalExpression ')'
-    ;
+PrimaryExpression: IdentifierReference | Constant | ParenthesisExpression;
 
-Variable hidden()
-	:	FunctionDefinition|DirectDeclarator|Field
-	;
+ParenthesisExpression: '(' inner=ConditionalExpression ')';
 
-StringLiteral
-    :   value=ENCSTRINGCONST
-	|   value=STRING
-    ;
+IdentifierReference: identifier=[Identifier];
 
-ConstantExpression returns Expression
-    :   ConditionalExpression
-    ;
+Identifier hidden(): FunctionDefinition | DirectDeclarator | BitField;
+
+ConstantExpression returns Expression: ConditionalExpression;
+    
 ///////////////////////////////////////////////////////////////////////////////
 // Constants
 Constant
-    :   IntegerConstant
-    |	FloatingConstant
-    |   CharacterConstant
-    |   BoolConstant
-    ;
+	:	IntegerConstant
+	|	FloatConstant
+	|	CharacterConstant
+	|	BoolConstant
+	|	StringConstant
+	;
 
-IntegerConstant hidden(WS)
-    :   value=INTEGER
-    ;
-
-FloatingConstant hidden(WS)
-    :  	value=FLOAT
-    ;
-    
-BoolConstant
-    :   value=BOOLEAN
-    ;
-    
-CharacterConstant
-    :   value=CHARCONST
-    ;
+IntegerConstant hidden(WS): value=INTEGER;
+FloatConstant hidden(WS): value=FLOAT;
+CharacterConstant: value=CHARCONST;
+BoolConstant: value=BOOLEAN;
+StringConstant: literals+=StringLiteral+;
+StringLiteral: value=ENCSTRINGCONST | value=STRING ;
 
 // the following 2 rules are needed so that XText does not generate a terminal symbol '[[' and '&&'
 // which is always eaten by the Lexer so that a[b[3]] is not recognized

--- a/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
@@ -9,17 +9,16 @@ import com.minres.coredsl.coreDsl.CharacterConstant
 import com.minres.coredsl.coreDsl.ConditionalExpression
 import com.minres.coredsl.coreDsl.DirectDeclarator
 import com.minres.coredsl.coreDsl.Expression
-import com.minres.coredsl.coreDsl.FloatingConstant
+import com.minres.coredsl.coreDsl.FloatConstant
 import com.minres.coredsl.coreDsl.FunctionDefinition
+import com.minres.coredsl.coreDsl.Identifier
 import com.minres.coredsl.coreDsl.InfixExpression
 import com.minres.coredsl.coreDsl.InitDeclarator
 import com.minres.coredsl.coreDsl.IntegerConstant
 import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
-import com.minres.coredsl.coreDsl.PrimaryExpression
 import com.minres.coredsl.coreDsl.StringLiteral
 import com.minres.coredsl.coreDsl.TypeSpecifier
-import com.minres.coredsl.coreDsl.Variable
 import com.minres.coredsl.typing.DataType
 import com.minres.coredsl.util.BigDecimalWithSize
 import com.minres.coredsl.util.BigIntegerWithRadix
@@ -35,6 +34,9 @@ import com.minres.coredsl.coreDsl.ExpressionStatement
 import com.minres.coredsl.coreDsl.FunctionCallExpression
 import com.minres.coredsl.coreDsl.ArrayAccessExpression
 import com.minres.coredsl.coreDsl.MemberAccessExpression
+import com.minres.coredsl.coreDsl.ParenthesisExpression
+import com.minres.coredsl.coreDsl.IdentifierReference
+import com.minres.coredsl.coreDsl.StringConstant
 
 class CoreDSLInterpreter {
 
@@ -66,7 +68,7 @@ class CoreDSLInterpreter {
 					.filter[it instanceof AssignmentExpression]]
 				.flatten
 			val declAssignment = assignments.filter [
-				it.left instanceof PrimaryExpression && (it.left as PrimaryExpression).ref == decl
+				it.left instanceof IdentifierReference && (it.left as IdentifierReference).identifier == decl
 			].last
 			if (declAssignment === null) {
 				val initDecl = (decl.eContainer as InitDeclarator)
@@ -180,16 +182,15 @@ class CoreDSLInterpreter {
 		return null;
 	}
 
-	def static dispatch Value valueFor(PrimaryExpression e, EvaluationContext ctx) {
-		if (e.constant !== null) {
-			e.constant.valueFor(ctx)
-		} else if (e.ref !== null) {
-			e.ref.valueFor(ctx)
-		} else
-			return null
+	def static dispatch Value valueFor(ParenthesisExpression e, EvaluationContext ctx) {
+		return e.inner.valueFor(ctx);
+	}
+	
+	def static dispatch Value valueFor(IdentifierReference e, EvaluationContext ctx) {
+		return e.identifier.valueFor(ctx);
 	}
 
-	def static dispatch Value valueFor(Variable e, EvaluationContext ctx) {
+	def static dispatch Value valueFor(Identifier e, EvaluationContext ctx) {
 		null
 	}
 
@@ -225,7 +226,7 @@ class CoreDSLInterpreter {
 		new Value(e.typeFor(ctx.definitionContext), e.value as BigIntegerWithRadix)
 	}
 
-	def static dispatch Value valueFor(FloatingConstant e, EvaluationContext ctx) {
+	def static dispatch Value valueFor(FloatConstant e, EvaluationContext ctx) {
 		new Value(e.typeFor(ctx.definitionContext), e.value as BigDecimalWithSize)
 	}
 
@@ -235,6 +236,10 @@ class CoreDSLInterpreter {
 
 	def static dispatch Value valueFor(CharacterConstant e, EvaluationContext ctx) {
 		new Value(new DataType(DataType.Type.INTEGRAL_SIGNED, 8), BigInteger.valueOf(e.value.charAt(0)))
+	}
+
+	def static dispatch Value valueFor(StringConstant e, EvaluationContext ctx) {
+		new Value(new DataType(DataType.Type.INTEGRAL_SIGNED, 0), null)
 	}
 
 	def static dispatch Value valueFor(StringLiteral e, EvaluationContext ctx) {

--- a/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
@@ -16,7 +16,7 @@ import com.minres.coredsl.coreDsl.DirectDeclarator
 import com.minres.coredsl.coreDsl.Encoding
 import com.minres.coredsl.coreDsl.Expression
 import com.minres.coredsl.coreDsl.ExpressionStatement
-import com.minres.coredsl.coreDsl.FloatingConstant
+import com.minres.coredsl.coreDsl.FloatConstant
 import com.minres.coredsl.coreDsl.FunctionDefinition
 import com.minres.coredsl.coreDsl.IfStatement
 import com.minres.coredsl.coreDsl.Import
@@ -33,7 +33,6 @@ import com.minres.coredsl.coreDsl.ParameterDeclaration
 import com.minres.coredsl.coreDsl.ParameterList
 import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
-import com.minres.coredsl.coreDsl.PrimaryExpression
 import com.minres.coredsl.coreDsl.SpawnStatement
 import com.minres.coredsl.coreDsl.StringLiteral
 import com.minres.coredsl.coreDsl.StructDeclaration
@@ -63,6 +62,10 @@ import com.minres.coredsl.coreDsl.BoolTypeSpecifier
 import com.minres.coredsl.coreDsl.VoidTypeSpecifier
 import com.minres.coredsl.coreDsl.FloatTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
+import com.minres.coredsl.coreDsl.IdentifierReference
+import com.minres.coredsl.coreDsl.CharacterConstant
+import com.minres.coredsl.coreDsl.StringConstant
+import com.minres.coredsl.coreDsl.ParenthesisExpression
 
 class Visualizer {
 	
@@ -454,12 +457,26 @@ class Visualizer {
 		return makeImmediateLiteral(node.value.toString)
 	}
 	
-	private def dispatch VisualNode genNode(FloatingConstant node) {
+	private def dispatch VisualNode genNode(FloatConstant node) {
 		return makeImmediateLiteral(node.value.toString)
 	}
 	
 	private def dispatch VisualNode genNode(BoolConstant node) {
 		return makeImmediateLiteral(node.value.toString)
+	}
+	
+	private def dispatch VisualNode genNode(CharacterConstant node) {
+		return makeImmediateLiteral(node.value)
+	}
+	
+	private def dispatch VisualNode genNode(StringConstant node) {
+		if(node.literals.size == 1) {
+			return visit(node.literals.get(0));
+		}
+		
+		return makeNode(node, "Compound String Constant",
+			makeGroup("Literals", node.literals)
+		);
 	}
 	
 	private def dispatch VisualNode genNode(StringLiteral node) {
@@ -507,28 +524,21 @@ class Visualizer {
 		);
 	}
 	
-	private def dispatch VisualNode genNode(PrimaryExpression node) {
-		if(node.left !== null)
-			return visit(node.left);
-			
-		if(node.ref instanceof FunctionDefinition)
-			return makeNode(node, "Function Reference", makeReference("Function", (node.ref as FunctionDefinition).name, [node.ref]));
-			
-		if(node.ref instanceof DirectDeclarator)
-			return makeNode(node, "Declarator Reference", makeReference("Declarator", (node.ref as DirectDeclarator).name, [node.ref]));
-			
-		if(node.ref instanceof BitField)
-			return makeNode(node, "Field Reference", makeReference("Field", (node.ref as BitField).name, [node.ref]));
-		
-		if(node.constant !== null)
-			return visit(node.constant);
-		
-		if(node.literal.size == 1)
-			return visit(node.literal.get(0));
-		
-		return makeNode(node, "Compound String Literal",
-			makeGroup("Literals", node.literal)
+	private def dispatch VisualNode genNode(ParenthesisExpression node) {
+		return makeNode(node, "Parenthesis Expression",
+			makeChild("Inner", node.inner)
 		);
+	}
+	
+	private def dispatch VisualNode genNode(IdentifierReference node) {
+		if(node.identifier instanceof FunctionDefinition)
+			return makeNode(node, "Function Reference", makeReference("Function", (node.identifier as FunctionDefinition).name, [node.identifier]));
+			
+		if(node.identifier instanceof DirectDeclarator)
+			return makeNode(node, "Declarator Reference", makeReference("Declarator", (node.identifier as DirectDeclarator).name, [node.identifier]));
+			
+		if(node.identifier instanceof BitField)
+			return makeNode(node, "Field Reference", makeReference("Field", (node.identifier as BitField).name, [node.identifier]));
 	}
 	
 	private def dispatch VisualNode genNode(Expression node) {

--- a/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
@@ -12,21 +12,20 @@ import com.minres.coredsl.coreDsl.Declaration
 import com.minres.coredsl.coreDsl.DirectDeclarator
 import com.minres.coredsl.coreDsl.EnumTypeSpecifier
 import com.minres.coredsl.coreDsl.Expression
-import com.minres.coredsl.coreDsl.FloatingConstant
+import com.minres.coredsl.coreDsl.FloatConstant
 import com.minres.coredsl.coreDsl.FunctionDefinition
+import com.minres.coredsl.coreDsl.Identifier
 import com.minres.coredsl.coreDsl.InfixExpression
 import com.minres.coredsl.coreDsl.InitDeclarator
 import com.minres.coredsl.coreDsl.IntegerConstant
 import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
-import com.minres.coredsl.coreDsl.PrimaryExpression
 import com.minres.coredsl.coreDsl.StringLiteral
 import com.minres.coredsl.coreDsl.Encoding
 import com.minres.coredsl.coreDsl.Field
 import com.minres.coredsl.coreDsl.ISA
 import com.minres.coredsl.coreDsl.TypeSpecifier
 import com.minres.coredsl.coreDsl.Constant
-import com.minres.coredsl.coreDsl.Variable
 import com.minres.coredsl.util.BigDecimalWithSize
 import com.minres.coredsl.util.BigIntegerWithRadix
 
@@ -43,6 +42,9 @@ import com.minres.coredsl.coreDsl.FloatSizeShorthand
 import com.minres.coredsl.coreDsl.BoolTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerSignedness
+import com.minres.coredsl.coreDsl.ParenthesisExpression
+import com.minres.coredsl.coreDsl.IdentifierReference
+import com.minres.coredsl.coreDsl.StringConstant
 
 class TypeProvider {
 
@@ -213,20 +215,15 @@ class TypeProvider {
         return e.declarator.typeFor(ctx);
     }
 
-    def static dispatch DataType typeFor(PrimaryExpression e, ISA ctx) {
-        if(e.constant !== null) {
-            e.constant.typeFor(ctx)
-        } else if(e.ref !== null ){
-            e.ref.typeFor(ctx)
-        } else if(e.left !== null ){
-            e.left.typeFor(ctx)
-        } else if(e.literal.size>0 ){
-        	throw new UnsupportedOperationException
-        } else
-            return null
+    def static dispatch DataType typeFor(ParenthesisExpression e, ISA ctx) {
+        return e.inner.typeFor(ctx);
     }
     
-    def static dispatch DataType typeFor(Variable e, ISA ctx) {
+    def static dispatch DataType typeFor(IdentifierReference e, ISA ctx) {
+        return e.identifier.typeFor(ctx);
+    }
+    
+    def static dispatch DataType typeFor(Identifier e, ISA ctx) {
         null
     }
 
@@ -265,7 +262,7 @@ class TypeProvider {
         new DataType(value.type==BigIntegerWithRadix.TYPE.UNSIGNED?DataType.Type.INTEGRAL_UNSIGNED:DataType.Type.INTEGRAL_SIGNED, value.size)
     }
 
-    def static dispatch DataType typeFor(FloatingConstant e, ISA ctx) {
+    def static dispatch DataType typeFor(FloatConstant e, ISA ctx) {
         new DataType(DataType.Type.FLOAT, (e.value as BigDecimalWithSize).size)
     }
 
@@ -275,6 +272,10 @@ class TypeProvider {
 
     def static dispatch DataType typeFor(CharacterConstant e, ISA ctx) {
         new DataType(DataType.Type.INTEGRAL_SIGNED, 8)
+    }
+    
+    def static dispatch DataType typeFor(StringConstant e, ISA ctx) {
+        new DataType(DataType.Type.INTEGRAL_SIGNED, 0)
     }
     
     def static dispatch DataType typeFor(StringLiteral e, ISA ctx) {


### PR DESCRIPTION
This PR splits the `PrimaryExpression` grammar rule into `ParenthesisExpression`, `IdentifierReference`, and `Constant`.
It also renames `Variable` to `Identifier`.

`PrimaryExpression` was previously responsible for representing parenthesized expressions, identifier references, constant values and compound string literals. Each of these has now been promoted to a separate class, with `PrimaryExpression` as their super type.