### PR TITLE
Rename Identifier --> NamedEntity

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertTrue
 import com.minres.coredsl.coreDsl.FloatConstant
-import com.minres.coredsl.coreDsl.IdentifierReference
+import com.minres.coredsl.coreDsl.EntityReference
 
 @ExtendWith(InjectionExtension)
 @InjectWith(CoreDslInjectorProvider)
@@ -109,7 +109,7 @@ class CoreDslTerminalsTest {
         for (el : compound.items.subList(3, compound.items.size())) {
             if (el instanceof ExpressionStatement) {
                 val expr = el.expr.expressions.get(0) as AssignmentExpression
-                val lhsName = ((expr.left as IdentifierReference).identifier as Declarator).name;
+                val lhsName = ((expr.left as EntityReference).target as Declarator).name;
                 val rhs = expr.assignments.get(0).right as FloatConstant
                 val floatValue = rhs.value.doubleValue
                 if (lhsName == "d" || lhsName == "f")

--- a/com.minres.coredsl.ui/src/com/minres/coredsl/ui/outline/CoreDslOutlineTreeProvider.xtend
+++ b/com.minres.coredsl.ui/src/com/minres/coredsl/ui/outline/CoreDslOutlineTreeProvider.xtend
@@ -10,11 +10,11 @@ import com.minres.coredsl.coreDsl.Encoding
 import com.minres.coredsl.coreDsl.Instruction
 import com.minres.coredsl.coreDsl.InstructionSet
 import com.minres.coredsl.coreDsl.Statement
-import com.minres.coredsl.coreDsl.Identifier
 import org.eclipse.xtext.ui.editor.outline.IOutlineNode
 import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider
 import org.eclipse.xtext.ui.editor.outline.impl.DocumentRootNode
 import com.minres.coredsl.coreDsl.CoreDslPackage
+import com.minres.coredsl.coreDsl.NamedEntity
 
 /**
  * Customization of the default outline structure.
@@ -65,7 +65,7 @@ class CoreDslOutlineTreeProvider extends DefaultOutlineTreeProvider {
 		createNode(parentNode, stmt.behavior)
 	}
 
-	def boolean _isLeaf(Identifier variable) {
+	def boolean _isLeaf(NamedEntity variable) {
 		return true;
 	}
 

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -318,9 +318,9 @@ PrimaryExpression: IdentifierReference | Constant | ParenthesisExpression;
 
 ParenthesisExpression: '(' inner=ConditionalExpression ')';
 
-IdentifierReference: identifier=[Identifier];
+IdentifierReference: identifier=[NamedEntity];
 
-Identifier hidden(): FunctionDefinition | Declarator | BitField;
+NamedEntity hidden(): FunctionDefinition | Declarator | BitField;
 
 ConstantExpression returns Expression: ConditionalExpression;
     

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -314,11 +314,11 @@ PostfixExpression:
 	|	{PostfixExpression.left=current} op='--'
 	)*;
 
-PrimaryExpression: IdentifierReference | Constant | ParenthesisExpression;
+PrimaryExpression: EntityReference | Constant | ParenthesisExpression;
 
 ParenthesisExpression: '(' inner=ConditionalExpression ')';
 
-IdentifierReference: identifier=[NamedEntity];
+EntityReference: target=[NamedEntity];
 
 NamedEntity hidden(): FunctionDefinition | Declarator | BitField;
 

--- a/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
@@ -34,10 +34,10 @@ import com.minres.coredsl.coreDsl.FunctionCallExpression
 import com.minres.coredsl.coreDsl.ArrayAccessExpression
 import com.minres.coredsl.coreDsl.MemberAccessExpression
 import com.minres.coredsl.coreDsl.ParenthesisExpression
-import com.minres.coredsl.coreDsl.IdentifierReference
 import com.minres.coredsl.coreDsl.StringConstant
 import com.minres.coredsl.coreDsl.ExpressionInitializer
 import com.minres.coredsl.coreDsl.NamedEntity
+import com.minres.coredsl.coreDsl.EntityReference
 
 class CoreDSLInterpreter {
 
@@ -69,7 +69,7 @@ class CoreDSLInterpreter {
 					.filter[it instanceof AssignmentExpression]]
 				.flatten
 			val declAssignment = assignments.filter [
-				it.left instanceof IdentifierReference && (it.left as IdentifierReference).identifier == decl
+				it.left instanceof EntityReference && (it.left as EntityReference).target == decl
 			].last
 			if (declAssignment === null) {
 				val initDecl = (decl.eContainer as InitDeclarator)
@@ -187,8 +187,8 @@ class CoreDSLInterpreter {
 		return e.inner.valueFor(ctx);
 	}
 	
-	def static dispatch Value valueFor(IdentifierReference e, EvaluationContext ctx) {
-		return e.identifier.valueFor(ctx);
+	def static dispatch Value valueFor(EntityReference e, EvaluationContext ctx) {
+		return e.target.valueFor(ctx);
 	}
 
 	def static dispatch Value valueFor(NamedEntity e, EvaluationContext ctx) {

--- a/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
@@ -11,7 +11,6 @@ import com.minres.coredsl.coreDsl.Declarator
 import com.minres.coredsl.coreDsl.Expression
 import com.minres.coredsl.coreDsl.FloatConstant
 import com.minres.coredsl.coreDsl.FunctionDefinition
-import com.minres.coredsl.coreDsl.Identifier
 import com.minres.coredsl.coreDsl.InfixExpression
 import com.minres.coredsl.coreDsl.InitDeclarator
 import com.minres.coredsl.coreDsl.IntegerConstant
@@ -38,6 +37,7 @@ import com.minres.coredsl.coreDsl.ParenthesisExpression
 import com.minres.coredsl.coreDsl.IdentifierReference
 import com.minres.coredsl.coreDsl.StringConstant
 import com.minres.coredsl.coreDsl.ExpressionInitializer
+import com.minres.coredsl.coreDsl.NamedEntity
 
 class CoreDSLInterpreter {
 
@@ -191,7 +191,7 @@ class CoreDSLInterpreter {
 		return e.identifier.valueFor(ctx);
 	}
 
-	def static dispatch Value valueFor(Identifier e, EvaluationContext ctx) {
+	def static dispatch Value valueFor(NamedEntity e, EvaluationContext ctx) {
 		null
 	}
 

--- a/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
@@ -29,8 +29,8 @@ import org.eclipse.xtext.scoping.Scopes
 
 import static extension com.minres.coredsl.util.ModelUtil.*
 import com.minres.coredsl.coreDsl.MemberAccessExpression
-import com.minres.coredsl.coreDsl.IdentifierReference
 import com.minres.coredsl.coreDsl.NamedEntity
+import com.minres.coredsl.coreDsl.EntityReference
 
 /**
  * This class contains custom scoping description.
@@ -252,8 +252,8 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
     /************************************************************************
      * Declarator extension methods begin
      */
-    def dispatch Declarator Declarator(IdentifierReference expression) {
-        expression.identifier instanceof Declarator? expression.identifier as Declarator : null
+    def dispatch Declarator Declarator(EntityReference expression) {
+        expression.target instanceof Declarator? expression.target as Declarator : null
     }
 
     def dispatch Declarator Declarator(MemberAccessExpression expression) {

--- a/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
@@ -12,7 +12,6 @@ import com.minres.coredsl.coreDsl.CoreDslPackage
 import com.minres.coredsl.coreDsl.Declaration
 import com.minres.coredsl.coreDsl.Declarator
 import com.minres.coredsl.coreDsl.FunctionDefinition
-import com.minres.coredsl.coreDsl.Identifier
 import com.minres.coredsl.coreDsl.ISA
 import com.minres.coredsl.coreDsl.Instruction
 import com.minres.coredsl.coreDsl.InstructionSet
@@ -31,6 +30,7 @@ import org.eclipse.xtext.scoping.Scopes
 import static extension com.minres.coredsl.util.ModelUtil.*
 import com.minres.coredsl.coreDsl.MemberAccessExpression
 import com.minres.coredsl.coreDsl.IdentifierReference
+import com.minres.coredsl.coreDsl.NamedEntity
 
 /**
  * This class contains custom scoping description.
@@ -42,7 +42,7 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
 
     override IScope getScope(EObject context, EReference reference){
         //println("scopre for "+reference.name+"(class "+reference.EReferenceType.name+") in context "+context.eClass.name)
-        if(reference.EReferenceType == CoreDslPackage.Literals.IDENTIFIER) {
+        if(reference.EReferenceType == CoreDslPackage.Literals.NAMED_ENTITY) {
             switch(context){
                 PrimaryExpression:
                     context.containingStatement.scopeForVariable(reference)
@@ -116,21 +116,21 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
         declsList.asScopes
     }
 		
-	def IScope asScopes(Iterable<Iterable<Identifier>> list){
+	def IScope asScopes(Iterable<Iterable<NamedEntity>> list){
 		if(list.empty)
 			IScope.NULLSCOPE
 		else
 			Scopes.scopeFor(list.last, list.take(list.size-1).asScopes)
 	}
 		
-    private def Iterable<Identifier> variables(ISA isa) {
+    private def Iterable<NamedEntity> variables(ISA isa) {
         #[isa.stateDeclarations].filter[it !== null].map [
             it.flatMap[declarators].map[it.declarator]
         ].flatten + isa.functions
     }
 
 		
-	def List<Iterable<Identifier>> variablesList(InstructionSet isa, Set<String> seen){
+	def List<Iterable<NamedEntity>> variablesList(InstructionSet isa, Set<String> seen){
 		seen.add(isa.name)
 		if(isa.superType !== null && !seen.contains(isa.superType.name)) {
 			val ret = isa.superType.variablesList(seen)

--- a/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
@@ -60,12 +60,12 @@ import com.minres.coredsl.coreDsl.BoolTypeSpecifier
 import com.minres.coredsl.coreDsl.VoidTypeSpecifier
 import com.minres.coredsl.coreDsl.FloatTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
-import com.minres.coredsl.coreDsl.IdentifierReference
 import com.minres.coredsl.coreDsl.CharacterConstant
 import com.minres.coredsl.coreDsl.StringConstant
 import com.minres.coredsl.coreDsl.ParenthesisExpression
 import com.minres.coredsl.coreDsl.ExpressionInitializer
 import com.minres.coredsl.coreDsl.ListInitializer
+import com.minres.coredsl.coreDsl.EntityReference
 
 class Visualizer {
 	
@@ -527,15 +527,15 @@ class Visualizer {
 		);
 	}
 	
-	private def dispatch VisualNode genNode(IdentifierReference node) {
-		if(node.identifier instanceof FunctionDefinition)
-			return makeNode(node, "Function Reference", makeReference("Function", (node.identifier as FunctionDefinition).name, [node.identifier]));
+	private def dispatch VisualNode genNode(EntityReference node) {
+		if(node.target instanceof FunctionDefinition)
+			return makeNode(node, "Function Reference", makeReference("Function", (node.target as FunctionDefinition).name, [node.target]));
 			
-		if(node.identifier instanceof Declarator)
-			return makeNode(node, "Declarator Reference", makeReference("Declarator", (node.identifier as Declarator).name, [node.identifier]));
+		if(node.target instanceof Declarator)
+			return makeNode(node, "Declarator Reference", makeReference("Declarator", (node.target as Declarator).name, [node.target]));
 			
-		if(node.identifier instanceof BitField)
-			return makeNode(node, "Field Reference", makeReference("Field", (node.identifier as BitField).name, [node.identifier]));
+		if(node.target instanceof BitField)
+			return makeNode(node, "Field Reference", makeReference("Field", (node.target as BitField).name, [node.target]));
 	}
 	
 	private def dispatch VisualNode genNode(Expression node) {

--- a/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
@@ -41,10 +41,10 @@ import com.minres.coredsl.coreDsl.BoolTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerSignedness
 import com.minres.coredsl.coreDsl.ParenthesisExpression
-import com.minres.coredsl.coreDsl.IdentifierReference
 import com.minres.coredsl.coreDsl.StringConstant
 import com.minres.coredsl.coreDsl.InitDeclarator
 import com.minres.coredsl.coreDsl.NamedEntity
+import com.minres.coredsl.coreDsl.EntityReference
 
 class TypeProvider {
 
@@ -219,8 +219,8 @@ class TypeProvider {
         return e.inner.typeFor(ctx);
     }
     
-    def static dispatch DataType typeFor(IdentifierReference e, ISA ctx) {
-        return e.identifier.typeFor(ctx);
+    def static dispatch DataType typeFor(EntityReference e, ISA ctx) {
+        return e.target.typeFor(ctx);
     }
     
     def static dispatch DataType typeFor(NamedEntity e, ISA ctx) {

--- a/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
@@ -14,7 +14,6 @@ import com.minres.coredsl.coreDsl.EnumTypeSpecifier
 import com.minres.coredsl.coreDsl.Expression
 import com.minres.coredsl.coreDsl.FloatConstant
 import com.minres.coredsl.coreDsl.FunctionDefinition
-import com.minres.coredsl.coreDsl.Identifier
 import com.minres.coredsl.coreDsl.InfixExpression
 import com.minres.coredsl.coreDsl.IntegerConstant
 import com.minres.coredsl.coreDsl.PostfixExpression
@@ -45,6 +44,7 @@ import com.minres.coredsl.coreDsl.ParenthesisExpression
 import com.minres.coredsl.coreDsl.IdentifierReference
 import com.minres.coredsl.coreDsl.StringConstant
 import com.minres.coredsl.coreDsl.InitDeclarator
+import com.minres.coredsl.coreDsl.NamedEntity
 
 class TypeProvider {
 
@@ -223,7 +223,7 @@ class TypeProvider {
         return e.identifier.typeFor(ctx);
     }
     
-    def static dispatch DataType typeFor(Identifier e, ISA ctx) {
+    def static dispatch DataType typeFor(NamedEntity e, ISA ctx) {
         null
     }
 


### PR DESCRIPTION
As discussed in #19, this PR renames `Identifier` to `NamedEntity`.
I also changed `IdentifierReference` to `Identifier.`