### PR TITLE
Rework ISA module grammar

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslInterpreterTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslInterpreterTest.xtend
@@ -44,7 +44,7 @@ class CoreDslInterpreterTest {
         '''.parse
         val issues = validator.validate(content)
         assertTrue(issues.isEmpty())
-        val constants = content.definitions.get(0).stateDeclarations
+        val constants = content.definitions.get(0).declarations
         val rootContext = EvaluationContext.root
         val values  = constants.flatMap[declaration |
             declaration.declarators.map[initDecl|

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
@@ -48,19 +48,19 @@ class CoreDslTypeTest {
         for (iss : issues)
             println(iss)
         assertTrue(issues.isEmpty())
-        val xlen_type = content.definitions.get(0).stateDeclarations.get(0).type;
+        val xlen_type = content.definitions.get(0).declarations.get(0).type;
         assertTrue(xlen_type instanceof IntegerTypeSpecifier);
         assertEquals(IntegerSignedness.UNSIGNED, (xlen_type as IntegerTypeSpecifier).signedness)
         assertEquals(IntegerSizeShorthand.INT, (xlen_type as IntegerTypeSpecifier).shorthand)
-        val flen_type = content.definitions.get(0).stateDeclarations.get(1).type;
+        val flen_type = content.definitions.get(0).declarations.get(1).type;
         assertTrue(flen_type instanceof IntegerTypeSpecifier);
         assertEquals(IntegerSignedness.UNSIGNED, (flen_type as IntegerTypeSpecifier).signedness)
         assertEquals(IntegerSizeShorthand.INT, (flen_type as IntegerTypeSpecifier).shorthand)
-        val csr_size_type = content.definitions.get(0).stateDeclarations.get(2).type;
+        val csr_size_type = content.definitions.get(0).declarations.get(2).type;
         assertTrue(csr_size_type instanceof IntegerTypeSpecifier);
         assertEquals(IntegerSignedness.SIGNED, (csr_size_type as IntegerTypeSpecifier).signedness)
         assertEquals(IntegerSizeShorthand.INT, (csr_size_type as IntegerTypeSpecifier).shorthand)
-        val decl = content.definitions.get(0).stateDeclarations.get(3).declarators.get(0).declarator
+        val decl = content.definitions.get(0).declarations.get(3).declarators.get(0).declarator
         assertEquals("X", decl.name)
         val dataType = decl.typeFor(content.definitions.last)
         assertNotNull(dataType)

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
@@ -33,9 +33,9 @@ class CoreDslTypeTest {
         InstructionSet TestISA {
             architectural_state {
                 unsigned int XLEN;
-                unsigned FLEN;
+                unsigned int FLEN;
                 int CSR_SIZE;
-                unsigned<XLEN>  X[32];
+                unsigned<XLEN> X[32];
             }
         }
         Core TestCore provides TestISA {

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -140,7 +140,7 @@ PrimitiveTypeSpecifier
 	;
 
 IntegerTypeSpecifier
-	:	signedness=IntegerSignedness (shorthand=IntegerSizeShorthand | '<' size=PrimaryExpression '>')?
+	:	signedness=IntegerSignedness (shorthand=IntegerSizeShorthand | '<' size=PrimaryExpression '>')
 	|	shorthand=IntegerSizeShorthand
 	;
 
@@ -179,7 +179,8 @@ EnumMemberDeclaration
     ;
 
 InitDeclarator:
-	declarator=Declarator ('=' initializer=(ExpressionInitializer | ListInitializer))?;
+	declarator=Declarator
+	(t_equals='=' initializer=(ExpressionInitializer | ListInitializer))?;
 
 Declarator:
 	alias?='&'?

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -4,48 +4,18 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
 generate coreDsl "http://www.minres.com/coredsl/CoreDsl/2.0"
 
-DescriptionContent
-	: (imports+=Import)* definitions+=ISA+ 
-	;
+DescriptionContent: (imports+=Import)* definitions+=(InstructionSet | CoreDef)+;
 
-Import
-	: 'import' importURI=STRING
-	;
+Import: 'import' importURI=STRING;
 
-ISA
-	: InstructionSet
-	| CoreDef
-	;
+InstructionSet : 'InstructionSet' name=ID ( 'extends' superType=[InstructionSet] )? '{' ISA '}';
 
-InstructionSet :
-	'InstructionSet' name=ID ( 'extends' superType=[InstructionSet] )? '{' 
-        ( SectionArchState (SectionFunctions SectionInstructions? | SectionInstructions)?
-        | SectionFunctions (SectionArchState SectionInstructions? | SectionInstructions)?
-        | SectionInstructions (SectionArchState SectionFunctions? | SectionFunctions)?
-        )
-    '}'
-;
+CoreDef: 'Core' name=ID ( 'provides' contributingType+=[InstructionSet] (',' contributingType+=[InstructionSet])*)? '{' ISA '}';
 
-CoreDef:
-	'Core' name=ID ( 'provides' contributingType+=[InstructionSet] (',' contributingType+=[InstructionSet])*)? '{' 
-	    ( SectionArchState (SectionFunctions SectionInstructions? | SectionInstructions)?
-        | SectionFunctions (SectionArchState SectionInstructions? | SectionInstructions)?
-        | SectionInstructions (SectionArchState SectionFunctions? | SectionFunctions)?
-        )
-    '}'
-;
-
-fragment SectionArchState returns ISA:
-    'architectural_state' '{' declarations+=(Declaration | ExpressionStatement)+ '}'
-;
-
-fragment SectionFunctions returns ISA:
-    'functions' '{' functions+=FunctionDefinition+ '}'
-;
-
-fragment SectionInstructions returns ISA:
-    'instructions' commonInstructionAttributes+=Attribute* '{' instructions+=Instruction+ '}'
-;
+fragment ISA:
+	('architectural_state' '{' (declarations+=Declaration | assignments+=ExpressionStatement)+ '}')? &
+	('functions' '{' functions+=FunctionDefinition+ '}')? &
+	('instructions' commonInstructionAttributes+=Attribute* '{' instructions+=Instruction+ '}')?;
 
 Instruction:
 	name=ID attributes+=Attribute* '{' 

--- a/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
@@ -165,10 +165,10 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
     def Iterable<Declaration> allDeclarations(ISA isa) {
         if(isa instanceof InstructionSet) {
             val declsSuper = isa.superType!==null?isa.superType.allDeclarations:#[]
-            #[declsSuper, isa.stateDeclarations.filter[it instanceof Declaration]].flatten
+            declsSuper + isa.declarations
         } else if(isa instanceof CoreDef){
             val declsSuper = isa.contributingType.map[it.allDeclarations].flatten
-            #[declsSuper, isa.stateDeclarations.filter[it instanceof Declaration]].flatten
+            declsSuper + isa.declarations
         }
     }
     /*

--- a/com.minres.coredsl/src/com/minres/coredsl/util/ModelUtil.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/util/ModelUtil.xtend
@@ -13,7 +13,6 @@ import java.util.List
 import com.minres.coredsl.coreDsl.Encoding
 import com.minres.coredsl.coreDsl.BitField
 import com.minres.coredsl.coreDsl.BitValue
-import com.minres.coredsl.coreDsl.Statement
 import com.minres.coredsl.coreDsl.BlockItem
 import com.minres.coredsl.coreDsl.InitDeclarator
 
@@ -21,18 +20,8 @@ class ModelUtil {
     
     static val logger = Logger.getLogger(typeof(ModelUtil));
 
-    static def Iterable<Declaration> getStateDeclarations(ISA isa) {
-        isa.declarations.filter[it instanceof Declaration].map[it as Declaration]
-    }
-
-    static def Iterable<Statement> getStateStatements(ISA isa) {
-        isa.declarations.filter[it instanceof Statement].map[it as Statement]
-    }
-
     static def Iterable<Declarator> getStateDeclarators(ISA isa) {
-    	val declarators = isa.declarations.filter[it instanceof Declaration].map[(it as Declaration)]
-        declarators.map[it.declarators.map[it.declarator]]
-        .flatten
+        isa.declarations.flatMap[it.declarators.map[it.declarator]]
     }
 
     static def Iterable<Declarator> getStateConstDeclarators(ISA isa) {
@@ -103,16 +92,16 @@ class ModelUtil {
         switch(isa){
             CoreDef:
                 if (isa.contributingType.size == 0)
-                    isa.declarations
+                    return isa.declarations + isa.assignments
                 else {
-                    val instrSets = isa.contributingType?.map[InstructionSet i|i.allInstructionSets].flatten
+                    val instrSets = isa.contributingType?.flatMap[it.allInstructionSets]
                     val seen = newLinkedHashSet
                     seen.addAll(instrSets)
                     seen.add(isa)
-                    seen.map[ISA i|i.declarations].flatten
+                    return seen.flatMap[it.declarations + it.assignments]
                 }
             InstructionSet:
-                isa.allInstructionSets.map[ISA i| i.declarations].flatten
+                return isa.allInstructionSets.flatMap[it.declarations + it.assignments]
         }
     }
     


### PR DESCRIPTION
This PR changes the way `InstructionSet` and `CoreDef` nodes are parsed.
For now, the sections can be specified in any order, but if we decide to fix it in #24, the necessary change would just be to remove the two `&` symbols in the `ISA` rule.

More importantly, I decided to parse declarations and assignments into separate lists, instead of combining them into one list of mixed `BlockItem`s. This removes the need for unnecessary `filter` calls in many places (btw. `flatMap[]` exists, so there is no need to write it as `map[].flatten`).

Also @eyck `unsigned` is not a valid type, so I made the size specifier mandatory again. And the `t_equals=` is there for a reason, please don't remove that.