### PR TITLE
Allow signedness casts

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslInterpreterTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslInterpreterTest.xtend
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
 
 import static extension com.minres.coredsl.interpreter.CoreDSLInterpreter.*
-import static extension com.minres.coredsl.util.ModelUtil.*
 
 @ExtendWith(InjectionExtension)
 @InjectWith(CoreDslInjectorProvider)

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 
 import static extension com.minres.coredsl.typing.TypeProvider.*
-import static extension com.minres.coredsl.util.ModelUtil.*
 import com.minres.coredsl.coreDsl.IntegerSignedness
 import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerSizeShorthand

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -263,6 +263,7 @@ MultiplicativeExpression returns Expression
 CastExpression
     :   PrefixExpression
     |	'(' type=TypeSpecifier ')' left=CastExpression
+    |	'(' signedness=IntegerSignedness ')' left=CastExpression
     ;
 
 PrefixExpression

--- a/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
@@ -38,7 +38,6 @@ import com.minres.coredsl.coreDsl.StringConstant
 import com.minres.coredsl.coreDsl.ExpressionInitializer
 import com.minres.coredsl.coreDsl.NamedEntity
 import com.minres.coredsl.coreDsl.EntityReference
-import com.minres.coredsl.coreDsl.PrimaryExpression
 
 class CoreDSLInterpreter {
 


### PR DESCRIPTION
This should be the last grammar change for now.
It allows signess casts that preserve the bit size of the operand.