### PR TITLE
[Grammar] Flow Control Statements

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/syntax/CoreDslSyntaxTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/syntax/CoreDslSyntaxTest.xtend
@@ -457,8 +457,8 @@ class CoreDslSyntaxTest {
 			
 		'''.parseAsStatements().get(0) as IfStatement;
 
-		assertNull(ifstmt.elseStmt);
-		assertNotNull((ifstmt.thenStmt as IfStatement).elseStmt);
+		assertNull(ifstmt.elseBody);
+		assertNotNull((ifstmt.thenBody as IfStatement).elseBody);
 	}
 
 	@Test
@@ -586,14 +586,14 @@ class CoreDslSyntaxTest {
 			
 			switch(5) { case: }
 			
-		'''.parseAsStatement(), CoreDslPackage.Literals.LABELED_STATEMENT, IssueCodes.SyntaxError);
+		'''.parseAsStatement(), CoreDslPackage.Literals.SWITCH_SECTION, IssueCodes.SyntaxError);
 
 		// default must not have a condition
 		validator.assertError('''
 			
 			switch(5) { default 0: }
 			
-		'''.parseAsStatement(), CoreDslPackage.Literals.LABELED_STATEMENT, IssueCodes.SyntaxError);
+		'''.parseAsStatement(), CoreDslPackage.Literals.SWITCH_SECTION, IssueCodes.SyntaxError);
 	}
 
 	@Test

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/syntax/CoreDslSyntaxTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/syntax/CoreDslSyntaxTest.xtend
@@ -511,6 +511,9 @@ class CoreDslSyntaxTest {
 	def void parseSwitchStatementValid() {
 		val statements = '''
 			
+			// no sections
+			switch(1) { }
+			
 			// simple default
 			switch(1) { default: }
 			
@@ -572,14 +575,6 @@ class CoreDslSyntaxTest {
 			switch(5);
 			
 		'''.parseAsStatement(), CoreDslPackage.Literals.EXPRESSION_STATEMENT, IssueCodes.SyntaxError);
-
-		// at least one section is required (TODO why?)
-		// NOTE: the closing brace is parsed as the end of the (omitted) compound statement, hence the error location
-		validator.assertError('''
-			
-			switch(5) {}
-			
-		'''.parseAsStatement(), CoreDslPackage.Literals.COMPOUND_STATEMENT, IssueCodes.SyntaxError);
 
 		// case needs a condition
 		validator.assertError('''

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -59,13 +59,10 @@ Statement
     |   WhileLoop
     |   ForLoop
     |   DoLoop
-    |   JumpStatement
+    |   ContinueStatement
+    |   BreakStatement
+    |   ReturnStatement
     |   SpawnStatement
-    ;
-
-LabeledStatement
-    :   'case' constExpr=ConstantExpression ':' items+=Statement*
-    |   {LabeledStatement} 'default' ':' items+=Statement*
     ;
 
     
@@ -81,16 +78,26 @@ BlockItem
 ExpressionStatement
     :   {ExpressionStatement} expr=AssignmentExpression? ';'
     ;
+
+SpawnStatement
+    :   'spawn' stmt=Statement
+    ;
     
 //////////////////////////////// Flow Control ////////////////////////////////
 
-IfStatement
-    :   'if' '(' cond=ConditionalExpression ')' thenStmt=Statement (=> 'else' elseStmt=Statement)?
-    ;
+IfStatement:
+	'if' '(' condition=ConditionalExpression ')' thenBody=Statement (=> 'else' elseBody=Statement)?;
 
-SwitchStatement
-    :   'switch' '(' cond=ConditionalExpression ')' '{' items+=LabeledStatement+ '}'
-    ;
+SwitchStatement:
+	'switch' '(' condition=ConditionalExpression ')' '{' sections+=SwitchSection* '}';
+
+SwitchSection:
+	{CaseSection} 'case' condition=ConstantExpression ':' body+=BlockItem* |
+	{DefaultSection} 'default' ':' body+=BlockItem*;
+
+ContinueStatement: {ContinueStatement} 'continue' ';';
+BreakStatement: {BreakStatement} 'break' ';';
+ReturnStatement: {ReturnStatement} 'return' value=ConditionalExpression? ';';
 
 //////////////////////////////// Loops ////////////////////////////////
 
@@ -103,16 +110,6 @@ ForLoop: 'for' '('
 	')' body=Statement;
 
 DoLoop: 'do' body=Statement 'while' '(' condition=ConditionalExpression ')' ';';
-
-JumpStatement
-    :   type='continue' ';'
-    |   type='break' ';'
-    |   type='return' expr=ConditionalExpression? ';'
-    ;
-
-SpawnStatement
-    :   'spawn' stmt=Statement
-    ;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Declarations

--- a/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
@@ -24,8 +24,6 @@ import com.minres.coredsl.coreDsl.InitDeclarator
 import com.minres.coredsl.coreDsl.Instruction
 import com.minres.coredsl.coreDsl.InstructionSet
 import com.minres.coredsl.coreDsl.IntegerConstant
-import com.minres.coredsl.coreDsl.JumpStatement
-import com.minres.coredsl.coreDsl.LabeledStatement
 import com.minres.coredsl.coreDsl.ParameterDeclaration
 import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
@@ -67,6 +65,12 @@ import com.minres.coredsl.coreDsl.EntityReference
 import com.minres.coredsl.coreDsl.WhileLoop
 import com.minres.coredsl.coreDsl.ForLoop
 import com.minres.coredsl.coreDsl.DoLoop
+import com.minres.coredsl.coreDsl.CaseSection
+import com.minres.coredsl.coreDsl.DefaultSection
+import com.minres.coredsl.coreDsl.CastExpression
+import com.minres.coredsl.coreDsl.ContinueStatement
+import com.minres.coredsl.coreDsl.BreakStatement
+import com.minres.coredsl.coreDsl.ReturnStatement
 
 class Visualizer {
 	
@@ -289,10 +293,6 @@ class Visualizer {
 	
 	// statements
 	
-	private def dispatch VisualNode genNode(LabeledStatement node) {
-		return makeNode(node, node.constExpr !== null ? "Case" : "Default", node.items);
-	}
-	
 	private def dispatch VisualNode genNode(CompoundStatement node) {
 		return makeNode(node, "Compound Statement", node.items);
 	}
@@ -305,16 +305,29 @@ class Visualizer {
 	
 	private def dispatch VisualNode genNode(IfStatement node) {
 		return makeNode(node, "If Statement", 
-			makeChild("Condition", node.cond),
-			makeChild("Then Branch", node.thenStmt),
-			makeChild("Else Branch", node.elseStmt)
+			makeChild("Condition", node.condition),
+			makeChild("Then Branch", node.thenBody),
+			makeChild("Else Branch", node.elseBody)
 		);
 	}
 	
 	private def dispatch VisualNode genNode(SwitchStatement node) {
 		return makeNode(node, "Switch Statement",
-			makeChild("Condition", node.cond),
-			makeGroup("Branches", node.items)
+			makeChild("Condition", node.condition),
+			makeGroup("Branches", node.sections)
+		);
+	}
+	
+	private def dispatch VisualNode genNode(CaseSection node) {
+		return makeNode(node, "Case",
+			makeChild("Condition", node.condition),
+			makeGroup("Statements", node.body)
+		);
+	}
+	
+	private def dispatch VisualNode genNode(DefaultSection node) {
+		return makeNode(node, "Default",
+			makeGroup("Statements", node.body)
 		);
 	}
 	
@@ -342,9 +355,17 @@ class Visualizer {
 		);
 	}
 	
-	private def dispatch VisualNode genNode(JumpStatement node) {
-		return makeNode(node, "Jump (" + node.type + ")",
-			makeChild("Return Value", node.expr)
+	private def dispatch VisualNode genNode(ContinueStatement node) {
+		return makeNode(node, "Continue");
+	}
+	
+	private def dispatch VisualNode genNode(BreakStatement node) {
+		return makeNode(node, "Break");
+	}
+	
+	private def dispatch VisualNode genNode(ReturnStatement node) {
+		return makeNode(node, "Return",
+			makeChild("Return Value", node.value)
 		);
 	}
 	
@@ -541,7 +562,12 @@ class Visualizer {
 		);
 	}
 	
-	//TODO CastExpression
+	private def dispatch VisualNode genNode(CastExpression node) {
+		return makeNode(node, "Cast Expression",
+			makeChild("Target Type", node.type),
+			makeChild("Operand", node.left)
+		);
+	}
 	
 	private def dispatch VisualNode genNode(EntityReference node) {
 		if(node.target instanceof FunctionDefinition)


### PR DESCRIPTION
Implements proposals 4 and 5 from #37.

## Structure Changes
- Allow switch statements without any sections
- Split `JumpStatement` into `ContinueStatement`, `BreakStatement` and `ReturnStatement`

## Name Changes
| Old Class | Old Field			| New Class | New Field |
|---|---|---|---|
|`IfStatement`|`cond`			|`IfStatement`|`condition`|
|`IfStatement`|`thenStmt`		|`IfStatement`|`thenBody`|
|`IfStatement`|`elseStmt`		|`IfStatement`|`elseBody`|
|`SwitchStatement`|`cond`		|`SwitchStatement`|`condition`|
|`SwitchStatement`|`items`		|`SwitchStatement`|`sections`|
|`LabeledStatement`|`items`		|`SwitchSection`|`body`|
|`LabeledStatement`|`constExpr`	|`CaseSection`|`condition`|
|`JumpStatement`|`expr`			|`ReturnStatement`|`value`|