### PR TITLE
[Grammar] Statements and Declarations

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslInterpreterTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslInterpreterTest.xtend
@@ -46,8 +46,8 @@ class CoreDslInterpreterTest {
         val constants = content.definitions.get(0).declarations
         val rootContext = EvaluationContext.root
         val values  = constants.flatMap[declaration |
-            declaration.declarators.map[initDecl|
-                initDecl.declarator.evaluate(rootContext)
+            declaration.declaration.declarators.map[declarator|
+                declarator.evaluate(rootContext)
             ]
         ].toList
         assertTrue(values.get(0).value instanceof BigInteger)

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
@@ -77,9 +77,9 @@ class CoreDslTerminalsTest {
         validator.assertNoErrors(content)
 
         val compound = ((content.definitions.get(0) as InstructionSet).instructions.get(0).behavior as CompoundStatement)
-        for (el : compound.items) {
+        for (el : compound.statements) {
             if (el instanceof ExpressionStatement) {
-                val expr = el.expr as AssignmentExpression
+                val expr = el.expression as AssignmentExpression
                 val rhs = expr.assignments.get(0).right as IntegerConstant
                 assertEquals(rhs.value.intValue, 42)
             }
@@ -106,9 +106,9 @@ class CoreDslTerminalsTest {
         validator.assertNoErrors(content)
 
         val compound = ((content.definitions.get(0) as InstructionSet).instructions.get(0).behavior as CompoundStatement)
-        for (el : compound.items.subList(3, compound.items.size())) {
+        for (el : compound.statements.subList(3, compound.statements.size())) {
             if (el instanceof ExpressionStatement) {
-                val expr = el.expr as AssignmentExpression
+                val expr = el.expression as AssignmentExpression
                 val lhsName = ((expr.left as EntityReference).target as Declarator).name;
                 val rhs = expr.assignments.get(0).right as FloatConstant
                 val floatValue = rhs.value.doubleValue

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTypeTest.xtend
@@ -47,19 +47,19 @@ class CoreDslTypeTest {
         for (iss : issues)
             println(iss)
         assertTrue(issues.isEmpty())
-        val xlen_type = content.definitions.get(0).declarations.get(0).type;
+        val xlen_type = content.definitions.get(0).declarations.get(0).declaration.type;
         assertTrue(xlen_type instanceof IntegerTypeSpecifier);
         assertEquals(IntegerSignedness.UNSIGNED, (xlen_type as IntegerTypeSpecifier).signedness)
         assertEquals(IntegerSizeShorthand.INT, (xlen_type as IntegerTypeSpecifier).shorthand)
-        val flen_type = content.definitions.get(0).declarations.get(1).type;
+        val flen_type = content.definitions.get(0).declarations.get(1).declaration.type;
         assertTrue(flen_type instanceof IntegerTypeSpecifier);
         assertEquals(IntegerSignedness.UNSIGNED, (flen_type as IntegerTypeSpecifier).signedness)
         assertEquals(IntegerSizeShorthand.INT, (flen_type as IntegerTypeSpecifier).shorthand)
-        val csr_size_type = content.definitions.get(0).declarations.get(2).type;
+        val csr_size_type = content.definitions.get(0).declarations.get(2).declaration.type;
         assertTrue(csr_size_type instanceof IntegerTypeSpecifier);
         assertEquals(IntegerSignedness.SIGNED, (csr_size_type as IntegerTypeSpecifier).signedness)
         assertEquals(IntegerSizeShorthand.INT, (csr_size_type as IntegerTypeSpecifier).shorthand)
-        val decl = content.definitions.get(0).declarations.get(3).declarators.get(0).declarator
+        val decl = content.definitions.get(0).declarations.get(3).declaration.declarators.get(0)
         assertEquals("X", decl.name)
         val dataType = decl.typeFor(content.definitions.last)
         assertNotNull(dataType)

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/syntax/CoreDslSyntaxTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/syntax/CoreDslSyntaxTest.xtend
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.^extension.ExtendWith
 import com.minres.coredsl.coreDsl.Instruction
 import com.minres.coredsl.coreDsl.FunctionDefinition
-import com.minres.coredsl.coreDsl.BlockItem
 import org.eclipse.emf.common.util.EList
 import com.minres.coredsl.validation.IssueCodes
 import com.minres.coredsl.coreDsl.CoreDslPackage
 import static org.junit.jupiter.api.Assertions.*
 import com.minres.coredsl.coreDsl.IfStatement
+import com.minres.coredsl.coreDsl.Statement
 
 @ExtendWith(InjectionExtension)
 @InjectWith(CoreDslInjectorProvider)
@@ -49,7 +49,7 @@ class CoreDslSyntaxTest {
 		'''.parse().definitions.get(0).functions.get(0);
 	}
 
-	def EList<BlockItem> parseAsStatements(CharSequence str) {
+	def EList<Statement> parseAsStatements(CharSequence str) {
 		return '''
 			InstructionSet TestISA {
 			    functions {
@@ -58,10 +58,10 @@ class CoreDslSyntaxTest {
 			    	}
 			    }
 			}
-		'''.parse().definitions.get(0).functions.get(0).statement.items;
+		'''.parse().definitions.get(0).functions.get(0).body.statements;
 	}
 
-	def BlockItem parseAsStatement(CharSequence str) {
+	def Statement parseAsStatement(CharSequence str) {
 		return str.parseAsStatements().get(0);
 	}
 
@@ -574,7 +574,7 @@ class CoreDslSyntaxTest {
 			
 			switch(5);
 			
-		'''.parseAsStatement(), CoreDslPackage.Literals.EXPRESSION_STATEMENT, IssueCodes.SyntaxError);
+		'''.parseAsStatement(), CoreDslPackage.Literals.EMPTY_STATEMENT, IssueCodes.SyntaxError);
 
 		// case needs a condition
 		validator.assertError('''

--- a/com.minres.coredsl.ui/src/com/minres/coredsl/ui/labeling/CoreDslLabelProvider.xtend
+++ b/com.minres.coredsl.ui/src/com/minres/coredsl/ui/labeling/CoreDslLabelProvider.xtend
@@ -39,7 +39,7 @@ class CoreDslLabelProvider extends DefaultEObjectLabelProvider {
     }
 
 	def text(Declaration decl) {
-		decl.declarators.map[it.declarator!==null? it.declarator.name:it.declarator.name].join(', ')
+		decl.declarators.map[it.name].join(', ')
     }
 
 	def text(Instruction ele) {

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -4,6 +4,10 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
 generate coreDsl "http://www.minres.com/coredsl/CoreDsl/2.0"
 
+///////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// Top Level Definitions ////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
 DescriptionContent: (imports+=Import)* definitions+=(InstructionSet | CoreDef)+;
 
 Import: 'import' importURI=STRING;
@@ -13,7 +17,7 @@ InstructionSet : 'InstructionSet' name=ID ( 'extends' superType=[InstructionSet]
 CoreDef: 'Core' name=ID ( 'provides' contributingType+=[InstructionSet] (',' contributingType+=[InstructionSet])*)? '{' ISA '}';
 
 fragment ISA:
-	('architectural_state' '{' (declarations+=Declaration | assignments+=ExpressionStatement)+ '}')? &
+	('architectural_state' '{' (declarations+=DeclarationStatement | assignments+=ExpressionStatement)+ '}')? &
 	('functions' '{' functions+=FunctionDefinition+ '}')? &
 	('instructions' commonInstructionAttributes+=Attribute* '{' instructions+=Instruction+ '}')?;
 
@@ -44,45 +48,32 @@ BitField
 
 FunctionDefinition
 	:   extern?='extern' type=TypeSpecifier name=ID '(' (parameters+=ParameterDeclaration (',' parameters+=ParameterDeclaration)*)? ')' ';'
-	|   type=TypeSpecifier name=ID '(' (parameters+=ParameterDeclaration (',' parameters+=ParameterDeclaration)*)? ')' attributes+=Attribute* statement=CompoundStatement
+	|   type=TypeSpecifier name=ID '(' (parameters+=ParameterDeclaration (',' parameters+=ParameterDeclaration)*)? ')' attributes+=Attribute* body=CompoundStatement
 	;
 
-ParameterDeclaration: type=TypeSpecifier declarator=Declarator?;
+////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// Statements ////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
 
-///////////////////////////////////////////////////////////////////////////////
-// Statements
-Statement
-    :   CompoundStatement
-    |   ExpressionStatement
-    |   IfStatement
-    |   SwitchStatement
-    |   WhileLoop
-    |   ForLoop
-    |   DoLoop
-    |   ContinueStatement
-    |   BreakStatement
-    |   ReturnStatement
-    |   SpawnStatement
-    ;
+Statement:
+	EmptyStatement
+	| SpawnStatement
+	| CompoundStatement
+	| ExpressionStatement
+	| DeclarationStatement
+	| IfStatement
+	| SwitchStatement
+	| ContinueStatement
+	| BreakStatement
+	| ReturnStatement
+	| LoopStatement;
 
-    
-CompoundStatement
-    :   {CompoundStatement} '{' items+=BlockItem* '}'
-    ;
+EmptyStatement: {EmptyStatement} ';';
+SpawnStatement: 'spawn' body=Statement;
+CompoundStatement: {CompoundStatement} '{' statements+=Statement* '}';
+ExpressionStatement: expression=AssignmentExpression ';';
+DeclarationStatement: declaration=MultiInitDeclaration ';';
 
-BlockItem
-    :   Statement
-    |   Declaration
-    ;
-
-ExpressionStatement
-    :   {ExpressionStatement} expr=AssignmentExpression? ';'
-    ;
-
-SpawnStatement
-    :   'spawn' stmt=Statement
-    ;
-    
 //////////////////////////////// Flow Control ////////////////////////////////
 
 IfStatement:
@@ -92,8 +83,8 @@ SwitchStatement:
 	'switch' '(' condition=ConditionalExpression ')' '{' sections+=SwitchSection* '}';
 
 SwitchSection:
-	{CaseSection} 'case' condition=ConstantExpression ':' body+=BlockItem* |
-	{DefaultSection} 'default' ':' body+=BlockItem*;
+	{CaseSection} 'case' condition=ConstantExpression ':' body+=Statement* |
+	{DefaultSection} 'default' ':' body+=Statement*;
 
 ContinueStatement: {ContinueStatement} 'continue' ';';
 BreakStatement: {BreakStatement} 'break' ';';
@@ -101,26 +92,58 @@ ReturnStatement: {ReturnStatement} 'return' value=ConditionalExpression? ';';
 
 //////////////////////////////// Loops ////////////////////////////////
 
-WhileLoop: 'while' '(' condition=ConditionalExpression ')' body=Statement;
+LoopStatement: WhileLoop | ForLoop | DoLoop;
 
-ForLoop: 'for' '('
-	(startDeclaration=Declaration | startExpression=AssignmentExpression? ';')				// init statement
-	(condition=ConditionalExpression?) ';'													// condition
-	(loopExpressions+=AssignmentExpression (',' loopExpressions+=AssignmentExpression)*)?	// loop statements
+WhileLoop:
+	'while' '(' condition=ConditionalExpression ')' body=Statement;
+
+ForLoop:
+	'for' '('
+	(startDeclaration=MultiInitDeclaration | startExpression=AssignmentExpression?) ';'
+	(condition=ConditionalExpression?) ';'
+	(loopExpressions+=AssignmentExpression (',' loopExpressions+=AssignmentExpression)*)?
 	')' body=Statement;
 
-DoLoop: 'do' body=Statement 'while' '(' condition=ConditionalExpression ')' ';';
+DoLoop:
+	'do' body=Statement 'while' '(' condition=ConditionalExpression ')' ';';
 
-///////////////////////////////////////////////////////////////////////////////
-// Declarations
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// Declarations ////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+	
+ParameterDeclaration returns Declaration: Declaration<false, false>;
+MultiInitDeclaration returns Declaration: Declaration<true, true>;
+MultiDeclaration returns Declaration: Declaration<true, false>;
 
-Declaration:
+Declaration<allowMultiple, allowInit>:
 	(storage+=StorageClassSpecifier | qualifiers+=TypeQualifier | attributes+=Attribute)*
-	type=TypeSpecifier (declarators+=InitDeclarator (',' declarators+=InitDeclarator)*)? ';';
+	type=TypeSpecifier (declarators+=Declarator<allowInit> (<allowMultiple> ',' declarators+=Declarator<allowInit>)*)?;
 
-Attribute
-    :  	DoubleLeftBracket type=ID ('=' params+=ConditionalExpression | '(' params+=ConditionalExpression (',' params+=ConditionalExpression)* ')')? DoubleRightBracket
-    ;
+Declarator<allowInit>:
+	alias?='&'?
+	name=ID
+	(LEFT_BR dimensions+=ConstantExpression RIGHT_BR)*
+	attributes+=Attribute*
+	(<allowInit> t_equals='=' initializer=(ExpressionInitializer | ListInitializer))?;
+
+NamedEntity: FunctionDefinition | Declarator<true> | BitField;
+    
+Initializer: ExpressionInitializer | ListInitializer | DesignatedInitializer;
+
+ExpressionInitializer: expr=ConditionalExpression;
+
+ListInitializer: '{' initializers+=Initializer (',' initializers+=Initializer)* ','? '}';
+
+DesignatedInitializer: (designators+=Designator)+ '=' initializer=(ExpressionInitializer | ListInitializer);
+
+Designator: LEFT_BR idx=ConstantExpression RIGHT_BR | '.' prop=ID;
+
+Attribute:
+	DoubleLeftBracket type=ID
+	('=' parameters+=ConditionalExpression | '(' parameters+=ConditionalExpression (',' parameters+=ConditionalExpression)* ')')?
+	DoubleRightBracket;
+
+//////////////////////////////// Type Specifiers ////////////////////////////////
 
 TypeSpecifier
 	:	ValueTypeSpecifier
@@ -154,17 +177,8 @@ VoidTypeSpecifier
 	:	{VoidTypeSpecifier} 'void';
 
 CompositeTypeSpecifier
-    :   composeType=StructOrUnion name=ID? '{' (declaration += StructDeclaration)* '}'
+    :   composeType=StructOrUnion name=ID? '{' (declarations+=MultiDeclaration ';')* '}'
     |   composeType=StructOrUnion name=ID
-    ;
-
-StructDeclaration
-    :   specifier=StructDeclarationSpecifier declarator += Declarator(',' declarator+=Declarator)* ';'
-    ;
-
-StructDeclarationSpecifier
-    :   type=TypeSpecifier
-    |   qualifiers+=TypeQualifier
     ;
 	
 // TODO add optional size specifier after name? (':' size=IntegerTypeSpecifier)?
@@ -177,26 +191,6 @@ EnumMemberDeclaration
     :   name=ID
     |   name=ID '=' expression=ConstantExpression
     ;
-
-InitDeclarator:
-	declarator=Declarator
-	(t_equals='=' initializer=(ExpressionInitializer | ListInitializer))?;
-
-Declarator:
-	alias?='&'?
-	name=ID
-	(LEFT_BR dimensions+=ConstantExpression RIGHT_BR)*
-	attributes+=Attribute*;
-    
-Initializer: ExpressionInitializer | ListInitializer | DesignatedInitializer;
-
-ExpressionInitializer: expr=ConditionalExpression;
-
-ListInitializer: '{' initializers+=Initializer (',' initializers+=Initializer)* ','? '}';
-
-DesignatedInitializer: (designators+=Designator)+ '=' initializer=(ExpressionInitializer | ListInitializer);
-
-Designator: LEFT_BR idx=ConstantExpression RIGHT_BR | '.' prop=ID;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Expressions
@@ -220,7 +214,7 @@ ConcatenationExpression returns Expression // right associative rule
     :   LogicalOrExpression ({InfixExpression.left=current} op='::' right=ConcatenationExpression)?
     ;
 
-// TODO issue: all left-associative infix expressions can have at most one operator of the same precedence because they are ? qualified.    
+// TODO issue: all left-associative infix expressions can have at most one operator of the same precedence because they are ? qualified.
 LogicalOrExpression returns Expression
     :   LogicalAndExpression ({InfixExpression.left=current} op='||' right=LogicalOrExpression)?
     ;
@@ -291,8 +285,6 @@ PrimaryExpression: EntityReference | Constant | ParenthesisExpression;
 ParenthesisExpression: '(' left=ConditionalExpression ')';
 
 EntityReference: target=[NamedEntity];
-
-NamedEntity hidden(): FunctionDefinition | Declarator | BitField;
 
 ConstantExpression returns Expression: ConditionalExpression;
     

--- a/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
@@ -20,17 +20,13 @@ import com.minres.coredsl.coreDsl.FunctionDefinition
 import com.minres.coredsl.coreDsl.IfStatement
 import com.minres.coredsl.coreDsl.Import
 import com.minres.coredsl.coreDsl.InfixExpression
-import com.minres.coredsl.coreDsl.InitDeclarator
 import com.minres.coredsl.coreDsl.Instruction
 import com.minres.coredsl.coreDsl.InstructionSet
 import com.minres.coredsl.coreDsl.IntegerConstant
-import com.minres.coredsl.coreDsl.ParameterDeclaration
 import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
 import com.minres.coredsl.coreDsl.SpawnStatement
 import com.minres.coredsl.coreDsl.StringLiteral
-import com.minres.coredsl.coreDsl.StructDeclaration
-import com.minres.coredsl.coreDsl.StructDeclarationSpecifier
 import com.minres.coredsl.coreDsl.StructOrUnion
 import com.minres.coredsl.coreDsl.SwitchStatement
 import com.minres.coredsl.services.visualization.VisualElement.DeclarationLiteral
@@ -279,27 +275,20 @@ class Visualizer {
 			makeChild("Return Type", node.type),
 			makeNamedLiteral("Name", node.name),
 			makeGroup("Parameters", node.parameters),
-			makeChild("Body", node.statement),
+			makeChild("Body", node.body),
 			makeGroup("Attributes", node.attributes)
-		);
-	}
-	
-	private def dispatch VisualNode genNode(ParameterDeclaration node) {
-		return makeNode(node, "Parameter",
-			makeChild("Type", node.type),
-			makeChild("Declarator", node.declarator)
 		);
 	}
 	
 	// statements
 	
 	private def dispatch VisualNode genNode(CompoundStatement node) {
-		return makeNode(node, "Compound Statement", node.items);
+		return makeNode(node, "Compound Statement", node.statements);
 	}
 	
 	private def dispatch VisualNode genNode(ExpressionStatement node) {
 		return makeNode(node, "Expression Statement", 
-			makeChild("Expression", node.expr)
+			makeChild("Expression", node.expression)
 		);
 	}
 	
@@ -371,7 +360,7 @@ class Visualizer {
 	
 	private def dispatch VisualNode genNode(SpawnStatement node) {
 		return makeNode(node, "Spawn Statement",
-			makeChild("Body", node.stmt)
+			makeChild("Body", node.body)
 		);
 	}
 	
@@ -390,7 +379,7 @@ class Visualizer {
 	private def dispatch VisualNode genNode(Attribute node) {
 		return makeNode(node, "Attribute",
 			makeNamedLiteral("Type", node.type.toString),
-			makeGroup("Params", node.params)
+			makeGroup("Parameters", node.parameters)
 		);
 	}
 	
@@ -419,7 +408,7 @@ class Visualizer {
 	private def dispatch VisualNode genNode(CompositeTypeSpecifier node) {
 		return makeNode(node, node.composeType == StructOrUnion.STRUCT ? "Struct Type" : "Union Type",
 			makeNamedLiteral("Name", node.name),
-			makeGroup("Declarations", node.declaration)
+			makeGroup("Declarations", node.declarations)
 		)
 	}
 	
@@ -430,32 +419,12 @@ class Visualizer {
 		)
 	}
 	
-	private def dispatch VisualNode genNode(StructDeclaration node) {
-		return makeNode(node, "Struct Declaration",
-			makeChild("Specifier", node.specifier),
-			makeGroup("Declarators", node.declarator)
-		)
-	}
-	
-	private def dispatch VisualNode genNode(StructDeclarationSpecifier node) {
-		return makeNode(node, "Struct Declaration Specifier",
-			makeChild("Type", node.type),
-			makePortGroup("Qualifiers", node.qualifiers.map[qualifier | makeImmediateLiteral(qualifier.toString)])
-		)
-	}
-	
-	private def dispatch VisualNode genNode(InitDeclarator node) {
-		return makeNode(node, "Init Declarator",
-			makeChild("Declarator", node.declarator),
-			makeChild("Initializer", node.initializer)
-		)
-	}
-	
 	private def dispatch VisualNode genNode(Declarator node) {
 		return makeNode(node, node.isAlias ? "Declarator (alias)" : "Declarator",
 			makeDeclaration("Name", node.name, node),
 			makeGroup("Dimensions", node.dimensions),
-			makeGroup("Attributes", node.attributes)
+			makeGroup("Attributes", node.attributes),
+			makeChild("Initializer", node.initializer)
 		);
 	}
 	

--- a/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
@@ -42,7 +42,6 @@ import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerSignedness
 import com.minres.coredsl.coreDsl.ParenthesisExpression
 import com.minres.coredsl.coreDsl.StringConstant
-import com.minres.coredsl.coreDsl.InitDeclarator
 import com.minres.coredsl.coreDsl.NamedEntity
 import com.minres.coredsl.coreDsl.EntityReference
 
@@ -221,8 +220,8 @@ class TypeProvider {
     }
 
     def static dispatch DataType typeFor(Declarator e, ISA ctx) {
-        if (e.eContainer instanceof InitDeclarator && e.eContainer.eContainer instanceof Declaration) {
-            var decl = e.eContainer.eContainer as Declaration
+        if (e.eContainer instanceof Declaration) {
+            var decl = e.eContainer as Declaration
             decl.type.typeFor(ctx)
         } else
             null

--- a/com.minres.coredsl/src/com/minres/coredsl/util/ModelUtil.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/util/ModelUtil.xtend
@@ -13,15 +13,14 @@ import java.util.List
 import com.minres.coredsl.coreDsl.Encoding
 import com.minres.coredsl.coreDsl.BitField
 import com.minres.coredsl.coreDsl.BitValue
-import com.minres.coredsl.coreDsl.BlockItem
-import com.minres.coredsl.coreDsl.InitDeclarator
+import com.minres.coredsl.coreDsl.Statement
 
 class ModelUtil {
     
     static val logger = Logger.getLogger(typeof(ModelUtil));
 
     static def Iterable<Declarator> getStateDeclarators(ISA isa) {
-        isa.declarations.flatMap[it.declarators.map[it.declarator]]
+        isa.declarations.flatMap[it.declaration.declarators]
     }
 
     static def Iterable<Declarator> getStateConstDeclarators(ISA isa) {
@@ -64,10 +63,10 @@ class ModelUtil {
     static def Declarator effectiveDeclarator(ISA isa, String name){
         if(isa instanceof CoreDef) {
             val decl = isa.allDefinitions.filter[it instanceof Declaration].findFirst[
-	           	(it as Declaration).declarators.findFirst[it.declarator.name==name]!==null
+	           	(it as Declaration).declarators.findFirst[it.name==name]!==null
             ]
             if(decl!==null) {
-                return (decl as Declaration).declarators.findFirst[it.declarator.name==name].declarator
+                return (decl as Declaration).declarators.findFirst[it.name==name]
             }
             for(contrib:isa.contributingType.reverseView) {
                 val contribDecl = contrib.effectiveDeclarator(name)
@@ -77,8 +76,7 @@ class ModelUtil {
         } else if(isa instanceof InstructionSet){
             val decl = isa.stateDeclarators.findFirst[it.name==name]
             if(decl!==null) {
-            	val init = decl.eContainer as InitDeclarator
-            	if(init.initializer !== null)
+            	if(decl.initializer !== null)
 	                return decl            	
             }
             val baseDecl = isa.superType.effectiveDeclarator(name)
@@ -88,7 +86,7 @@ class ModelUtil {
         null
     }
         
-    static def Iterable<BlockItem> allDefinitions(ISA isa){
+    static def Iterable<Statement> allDefinitions(ISA isa){
         switch(isa){
             CoreDef:
                 if (isa.contributingType.size == 0)

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/CoreDslValidator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/CoreDslValidator.xtend
@@ -115,7 +115,7 @@ class CoreDslValidator extends AbstractCoreDslValidator {
 			if(info === null || !info.allowedUsage.contains(expectedUsage))
 				error("unexpected attribute '" + attribute.type + "'", feature, ILLEGAL_ATTRIBUTE);
 			
-			if(attribute.params.size() !== info.paramCount)
+			if(attribute.parameters.size() !== info.paramCount)
 				error("attribute '" + info.name + "' requires exactly " + info.paramCount + " parameter(s)", feature, INVALID_ATTRIBUTE_PARAMETERS);
 		}
 	}


### PR DESCRIPTION
Implements proposal 6 from #37.

## General Remarks
This PR uses a feature of the XText Grammar Language which is could not find any reference to in the documentation. It allows the parametrization of parser rules, which I use to specify whether [declarations are allowed to contain multiple declarators](https://github.com/AtomCrafty/CoreDSL/commit/5307b69064357fc891156f476f23004a5991084a#diff-81c71c22b4c67ba62e7e6766c132447ff06b00fcafa77453e64eea358f3c9b38R118) and whether [declarators are allowed to contain an initializer](https://github.com/AtomCrafty/CoreDSL/commit/5307b69064357fc891156f476f23004a5991084a#diff-81c71c22b4c67ba62e7e6766c132447ff06b00fcafa77453e64eea358f3c9b38R122).

## Structure Changes
- Deleted class `BlockItem`
  - Added `DeclarationStatement` as a wrapper around `Declaration` instead
- Deleted classes `ParameterDeclaration` and `StructDeclaration`
  - Both were replaced with a regular `Declaration`
- Deleted class `InitDeclarator`
   - `initializer` is instead defined directly on the declarator class
- `ExpressionStatement` now requires an expression
  - To replace the previous functionality, `EmptyStatement` was introduced
- Added `LoopStatement` as the shared super type of all kinds of loops
- Added utility parser rules `ParameterDeclaration`, `MultiInitDeclaration` and `MultiDeclaration`


## Name Changes
| Old Class | Old Field			| New Class | New Field |
|---|---|---|---|
|`CompondStatement`|`items`			|`CompondStatement`|`statements`|
|`ExpressionStatement`|`expr`		|`ExpressionStatement`|`expression`|
|`SpawnStatement`|`stmt`		|`SpawnStatement`|`body`|
|`FunctionDefinition`|`statement`		|`FunctionDefinition`|`body`|