### PR TITLE
[Grammar] Expressions

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTerminalsTest.xtend
@@ -80,7 +80,7 @@ class CoreDslTerminalsTest {
         for (el : compound.statements) {
             if (el instanceof ExpressionStatement) {
                 val expr = el.expression as AssignmentExpression
-                val rhs = expr.assignments.get(0).right as IntegerConstant
+                val rhs = expr.value as IntegerConstant
                 assertEquals(rhs.value.intValue, 42)
             }
         }
@@ -109,8 +109,8 @@ class CoreDslTerminalsTest {
         for (el : compound.statements.subList(3, compound.statements.size())) {
             if (el instanceof ExpressionStatement) {
                 val expr = el.expression as AssignmentExpression
-                val lhsName = ((expr.left as EntityReference).target as Declarator).name;
-                val rhs = expr.assignments.get(0).right as FloatConstant
+                val lhsName = ((expr.target as EntityReference).target as Declarator).name;
+                val rhs = expr.value as FloatConstant
                 val floatValue = rhs.value.doubleValue
                 if (lhsName == "d" || lhsName == "f")
                     assertTrue(Math.abs(floatValue - 3.14) < 1e-6)

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -192,8 +192,9 @@ EnumMemberDeclaration
     |   name=ID '=' expression=ConstantExpression
     ;
 
-///////////////////////////////////////////////////////////////////////////////
-// Expressions
+/////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// Expressions ////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
 
 // TODO AssignmentExpression should be inserted in the precedence hierarchy between ConditionalExpression and ConcatenationExpression
 AssignmentExpression returns Expression // this is right associative
@@ -255,22 +256,22 @@ MultiplicativeExpression returns Expression
     :   CastExpression ({InfixExpression.left=current} op=('*' | '/' | '%') right=MultiplicativeExpression)?
     ;
 
-CastExpression
+CastExpression returns Expression
     :   PrefixExpression
-    |	'(' type=TypeSpecifier ')' left=CastExpression
-    |	'(' signedness=IntegerSignedness ')' left=CastExpression
+    |	{CastExpression} '(' type=TypeSpecifier ')' left=CastExpression
+    |	{CastExpression} '(' signedness=IntegerSignedness ')' left=CastExpression
     ;
 
-PrefixExpression
+PrefixExpression returns Expression
     :   PostfixExpression
-    |   op='++' left=PrefixExpression
-    |   op='--' left=PrefixExpression
-    |   op=('&' | '*' | '+' | '-' | '~' | '!') left=CastExpression
-    |   op='sizeof' '(' (left=PostfixExpression |  type=TypeSpecifier ) ')'
+    |   {PrefixExpression} op='++' left=PrefixExpression
+    |   {PrefixExpression} op='--' left=PrefixExpression
+    |   {PrefixExpression} op=('&' | '*' | '+' | '-' | '~' | '!') left=CastExpression
+    |   {PrefixExpression} op='sizeof' '(' (left=PostfixExpression |  type=TypeSpecifier ) ')'
 //    |   op='_Alignof' '(' type=TypeSpecifier ')'
     ;
 
-PostfixExpression:
+PostfixExpression returns Expression:
 	PrimaryExpression
 	(	{FunctionCallExpression.left=current} '(' (arguments+=ConditionalExpression (',' arguments+=ConditionalExpression)*)? ')'
 	|	{ArrayAccessExpression.left=current} LEFT_BR index=ConditionalExpression (':' endIndex=ConditionalExpression)? RIGHT_BR

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -77,13 +77,13 @@ DeclarationStatement: declaration=MultiInitDeclaration ';';
 //////////////////////////////// Flow Control ////////////////////////////////
 
 IfStatement:
-	'if' '(' condition=ConditionalExpression ')' thenBody=Statement (=> 'else' elseBody=Statement)?;
+	'if' '(' condition=Expression ')' thenBody=Statement (=> 'else' elseBody=Statement)?;
 
 SwitchStatement:
-	'switch' '(' condition=ConditionalExpression ')' '{' sections+=SwitchSection* '}';
+	'switch' '(' condition=Expression ')' '{' sections+=SwitchSection* '}';
 
 SwitchSection:
-	{CaseSection} 'case' condition=ConstantExpression ':' body+=Statement* |
+	{CaseSection} 'case' condition=Expression ':' body+=Statement* |
 	{DefaultSection} 'default' ':' body+=Statement*;
 
 ContinueStatement: {ContinueStatement} 'continue' ';';
@@ -95,17 +95,17 @@ ReturnStatement: {ReturnStatement} 'return' value=ConditionalExpression? ';';
 LoopStatement: WhileLoop | ForLoop | DoLoop;
 
 WhileLoop:
-	'while' '(' condition=ConditionalExpression ')' body=Statement;
+	'while' '(' condition=Expression ')' body=Statement;
 
 ForLoop:
 	'for' '('
 	(startDeclaration=MultiInitDeclaration | startExpression=AssignmentExpression?) ';'
-	(condition=ConditionalExpression?) ';'
+	(condition=Expression?) ';'
 	(loopExpressions+=AssignmentExpression (',' loopExpressions+=AssignmentExpression)*)?
 	')' body=Statement;
 
 DoLoop:
-	'do' body=Statement 'while' '(' condition=ConditionalExpression ')' ';';
+	'do' body=Statement 'while' '(' condition=Expression ')' ';';
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Declarations ////////////////////////////////
@@ -122,7 +122,7 @@ Declaration<allowMultiple, allowInit>:
 Declarator<allowInit>:
 	alias?='&'?
 	name=ID
-	(LEFT_BR dimensions+=ConstantExpression RIGHT_BR)*
+	(LEFT_BR dimensions+=Expression RIGHT_BR)*
 	attributes+=Attribute*
 	(<allowInit> t_equals='=' initializer=(ExpressionInitializer | ListInitializer))?;
 
@@ -130,17 +130,17 @@ NamedEntity: FunctionDefinition | Declarator<true> | BitField;
     
 Initializer: ExpressionInitializer | ListInitializer | DesignatedInitializer;
 
-ExpressionInitializer: expr=ConditionalExpression;
+ExpressionInitializer: expr=Expression;
 
 ListInitializer: '{' initializers+=Initializer (',' initializers+=Initializer)* ','? '}';
 
 DesignatedInitializer: (designators+=Designator)+ '=' initializer=(ExpressionInitializer | ListInitializer);
 
-Designator: LEFT_BR idx=ConstantExpression RIGHT_BR | '.' prop=ID;
+Designator: LEFT_BR idx=Expression RIGHT_BR | '.' prop=ID;
 
 Attribute:
 	DoubleLeftBracket type=ID
-	('=' parameters+=ConditionalExpression | '(' parameters+=ConditionalExpression (',' parameters+=ConditionalExpression)* ')')?
+	('=' parameters+=Expression | '(' parameters+=Expression (',' parameters+=Expression)* ')')?
 	DoubleRightBracket;
 
 //////////////////////////////// Type Specifiers ////////////////////////////////
@@ -189,115 +189,85 @@ EnumTypeSpecifier
 
 EnumMemberDeclaration
     :   name=ID
-    |   name=ID '=' expression=ConstantExpression
+    |   name=ID '=' expression=Expression
     ;
 
 /////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Expressions ////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
 
-// TODO AssignmentExpression should be inserted in the precedence hierarchy between ConditionalExpression and ConcatenationExpression
-AssignmentExpression returns Expression // this is right associative
-    :   PrefixExpression ({AssignmentExpression.left=current} assignments+=Assignment)*
-    ;
+Expression: AssignmentExpression;
 
-// TODO remove this rule completely and instead use right-recursive pattern for AssignmentExpression
-Assignment:
-	type=('=' | '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '&=' | '^=' | '|=') right=ConditionalExpression
-	;
+AssignmentExpression returns Expression:
+	ConditionalExpression
+	({AssignmentExpression.target=current}
+		operator=('=' | '*=' | '/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '&=' | '^=' | '|=')
+		value=AssignmentExpression
+	)?;
 
-// TODO the then and else branches should allow AssignmentExpression
-ConditionalExpression returns Expression
-    :   ConcatenationExpression ({ConditionalExpression.cond=current} '?' left=ConditionalExpression ':' right=ConditionalExpression)?
-    ;
+ConditionalExpression returns Expression:
+	ConcatenationExpression
+	({ConditionalExpression.condition=current}
+		'?' thenExpression=AssignmentExpression
+		':' elseExpression=ConditionalExpression
+	)?;
 
-ConcatenationExpression returns Expression // right associative rule
-    :   LogicalOrExpression ({InfixExpression.left=current} op='::' right=ConcatenationExpression)?
-    ;
+ConcatenationExpression returns Expression:
+	LogicalOrExpression
+	({ConcatenationExpression.parts+=current}
+		('::' parts+=LogicalOrExpression)+
+	)?;
 
-// TODO issue: all left-associative infix expressions can have at most one operator of the same precedence because they are ? qualified.
-LogicalOrExpression returns Expression
-    :   LogicalAndExpression ({InfixExpression.left=current} op='||' right=LogicalOrExpression)?
-    ;
+LogicalOrExpression returns Expression: LogicalAndExpression ({InfixExpression.left=current} operator='||' right=LogicalAndExpression)*;
+LogicalAndExpression returns Expression: InclusiveOrExpression ({InfixExpression.left=current} operator='&&' right=InclusiveOrExpression)*;
+InclusiveOrExpression returns Expression: ExclusiveOrExpression ({InfixExpression.left=current} operator='|' right=ExclusiveOrExpression)*;
+ExclusiveOrExpression returns Expression: AndExpression ({InfixExpression.left=current} operator='^' right=AndExpression)*;
+AndExpression returns Expression: EqualityExpression ({InfixExpression.left=current} operator='&' right=EqualityExpression)*;
+EqualityExpression returns Expression: RelationalExpression ({InfixExpression.left=current} operator=('=='|'!=') right=RelationalExpression)*;
+RelationalExpression returns Expression: ShiftExpression ({InfixExpression.left=current} operator=('<'|'>'|'<='|'>=') right=ShiftExpression)*;
+ShiftExpression returns Expression: AdditiveExpression ({InfixExpression.left=current} operator=('<<'|'>>') right=AdditiveExpression)*;
+AdditiveExpression returns Expression: MultiplicativeExpression ({InfixExpression.left=current} operator=('+'|'-') right=MultiplicativeExpression)*;
+MultiplicativeExpression returns Expression: CastExpression ({InfixExpression.left=current} operator=('*' | '/' | '%') right=CastExpression)*;
 
-LogicalAndExpression returns Expression
-    :   InclusiveOrExpression ({InfixExpression.left=current} op='&&' right=LogicalAndExpression)?
-    ;
+CastExpression returns Expression:
+	PrefixExpression
+	| {CastExpression} '(' targetType=TypeSpecifier ')' operand=CastExpression
+	| {CastExpression} '(' signedness=IntegerSignedness ')' operand=CastExpression;
 
-InclusiveOrExpression returns Expression
-    :   ExclusiveOrExpression ({InfixExpression.left=current} op='|' right=InclusiveOrExpression)?
-    ;
-
-ExclusiveOrExpression returns Expression
-    :   AndExpression ({InfixExpression.left=current} op='^' right=ExclusiveOrExpression)?
-    ;
-
-AndExpression returns Expression
-    :   EqualityExpression ({InfixExpression.left=current} op='&' right=AndExpression)?
-    ;
-
-EqualityExpression returns Expression
-    :   RelationalExpression ({InfixExpression.left=current} op=('=='|'!=') right=EqualityExpression)?
-    ;
-
-RelationalExpression returns Expression
-    :   ShiftExpression ({InfixExpression.left=current} op=('<'|'>'|'<='|'>=') right=RelationalExpression)?
-    ;
-
-ShiftExpression returns Expression
-    :   AdditiveExpression ({InfixExpression.left=current} op=('<<'|'>>') right=ShiftExpression)?
-    ;
-
-AdditiveExpression returns Expression
-    :   MultiplicativeExpression ({InfixExpression.left=current} op=('+'|'-') right=AdditiveExpression)?
-    ;
-
-MultiplicativeExpression returns Expression
-    :   CastExpression ({InfixExpression.left=current} op=('*' | '/' | '%') right=MultiplicativeExpression)?
-    ;
-
-CastExpression returns Expression
-    :   PrefixExpression
-    |	{CastExpression} '(' type=TypeSpecifier ')' left=CastExpression
-    |	{CastExpression} '(' signedness=IntegerSignedness ')' left=CastExpression
-    ;
-
-PrefixExpression returns Expression
-    :   PostfixExpression
-    |   {PrefixExpression} op='++' left=PrefixExpression
-    |   {PrefixExpression} op='--' left=PrefixExpression
-    |   {PrefixExpression} op=('&' | '*' | '+' | '-' | '~' | '!') left=CastExpression
-    |   {PrefixExpression} op='sizeof' '(' (left=PostfixExpression |  type=TypeSpecifier ) ')'
-//    |   op='_Alignof' '(' type=TypeSpecifier ')'
+PrefixExpression returns Expression:
+	PostfixExpression
+	| {PrefixExpression} operator=('++' | '--') operand=PrefixExpression
+	| {PrefixExpression} operator=('+' | '-' | '~' | '!') operand=PrefixExpression
     ;
 
 PostfixExpression returns Expression:
 	PrimaryExpression
-	(	{FunctionCallExpression.left=current} '(' (arguments+=ConditionalExpression (',' arguments+=ConditionalExpression)*)? ')'
-	|	{ArrayAccessExpression.left=current} LEFT_BR index=ConditionalExpression (':' endIndex=ConditionalExpression)? RIGHT_BR
-	|	{MemberAccessExpression.left=current} op='.' declarator=[Declarator]
-	|	{MemberAccessExpression.left=current} op='->' declarator=[Declarator]
-	|	{PostfixExpression.left=current} op='++'
-	|	{PostfixExpression.left=current} op='--'
+	(	{FunctionCallExpression.target=current} '(' (arguments+=Expression (',' arguments+=Expression)*)? ')'
+	|	{ArrayAccessExpression.target=current} LEFT_BR index=Expression (':' endIndex=Expression)? RIGHT_BR
+	|	{MemberAccessExpression.target=current} operator='.' declarator=[Declarator]
+	|	{MemberAccessExpression.target=current} operator='->' declarator=[Declarator]
+	|	{PostfixExpression.operand=current} operator='++'
+	|	{PostfixExpression.operand=current} operator='--'
 	)*;
 
-PrimaryExpression: EntityReference | Constant | ParenthesisExpression;
+PrimaryExpression: ParenthesisExpression | EntityReference | IntrinsicExpression | Constant;
 
-ParenthesisExpression: '(' left=ConditionalExpression ')';
+ParenthesisExpression: '(' inner=Expression ')';
 
 EntityReference: target=[NamedEntity];
 
-ConstantExpression returns Expression: ConditionalExpression;
+IntrinsicExpression:
+	function=('sizeof' | 'bitsizeof' | 'alignof' | 'offsetof')
+	'(' (arguments+=(Expression|TypeSpecifier) (',' arguments+=(Expression|TypeSpecifier))*)? ')';
     
-///////////////////////////////////////////////////////////////////////////////
-// Constants
-Constant
-	:	IntegerConstant
-	|	FloatConstant
-	|	CharacterConstant
-	|	BoolConstant
-	|	StringConstant
-	;
+//////////////////////////////// Constants ////////////////////////////////
+
+Constant:
+	IntegerConstant
+	| FloatConstant
+	| CharacterConstant
+	| BoolConstant
+	| StringConstant;
 
 IntegerConstant hidden(WS): value=INTEGER;
 FloatConstant hidden(WS): value=FLOAT;
@@ -306,12 +276,9 @@ BoolConstant: value=BOOLEAN;
 StringConstant: literals+=StringLiteral+;
 StringLiteral: value=ENCSTRINGCONST | value=STRING ;
 
-// the following 2 rules are needed so that XText does not generate a terminal symbol '[[' and '&&'
-// which is always eaten by the Lexer so that a[b[3]] is not recognized
-DoubleLeftBracket hidden(WS, ML_COMMENT, SL_COMMENT): LEFT_BR LEFT_BR;
-DoubleRightBracket hidden(WS, ML_COMMENT, SL_COMMENT): RIGHT_BR RIGHT_BR;
-
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// Enumerations ////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
 
 enum IntegerSignedness : SIGNED='signed' | UNSIGNED='unsigned';
 
@@ -325,7 +292,14 @@ enum StorageClassSpecifier: EXTERN='extern' | STATIC='static' | REGISTER='regist
 
 enum StructOrUnion:   STRUCT='struct'|UNION='union';
 
-// TODO enum for assignment operators
+////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// Terminal Rules ////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+// The following 2 rules are needed so that XText does not generate the terminal symbols
+// '[[' and ']]', which are always eaten by the lexer so that a[b[3]] is not recognized.
+DoubleLeftBracket hidden(WS, ML_COMMENT, SL_COMMENT): LEFT_BR LEFT_BR;
+DoubleRightBracket hidden(WS, ML_COMMENT, SL_COMMENT): RIGHT_BR RIGHT_BR;
 
 terminal LEFT_BR: '[';
 

--- a/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
@@ -26,8 +26,6 @@ import java.math.BigInteger
 import static extension com.minres.coredsl.typing.TypeProvider.*
 import static extension com.minres.coredsl.util.ModelUtil.*
 import com.minres.coredsl.coreDsl.ISA
-import com.minres.coredsl.coreDsl.CoreDef
-import com.minres.coredsl.coreDsl.InstructionSet
 import com.minres.coredsl.coreDsl.ExpressionStatement
 import com.minres.coredsl.coreDsl.FunctionCallExpression
 import com.minres.coredsl.coreDsl.ArrayAccessExpression
@@ -37,7 +35,6 @@ import com.minres.coredsl.coreDsl.StringConstant
 import com.minres.coredsl.coreDsl.ExpressionInitializer
 import com.minres.coredsl.coreDsl.NamedEntity
 import com.minres.coredsl.coreDsl.EntityReference
-import org.eclipse.xtext.parser.packrat.tokens.AssignmentToken.End
 
 class CoreDSLInterpreter {
 
@@ -54,18 +51,13 @@ class CoreDSLInterpreter {
                 else
                     return null
             }
-            val stmts = switch (context) {
-                CoreDef: {
-                    context.allDefinitions
-                }
-                InstructionSet: {
-                    context.allDefinitions
-                }
-            }.toList
-            val assignments = stmts.filter[it instanceof ExpressionStatement].map [
-                (it as ExpressionStatement).expression
-            ]
-            val declAssignment = assignments.filter [
+            val stmts = context.allDefinitions.toList
+            val assignments = stmts
+            	.filter[it instanceof ExpressionStatement]
+            	.map[(it as ExpressionStatement).expression]
+            	.filter[it instanceof AssignmentExpression]
+            	.map[it as AssignmentExpression];
+            val declAssignment = assignments.filter[
                 it.left instanceof EntityReference && (it.left as EntityReference).target == decl
             ].last
             if (declAssignment === null) {

--- a/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
@@ -269,7 +269,7 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
     }
 
     def dispatch Declarator Declarator(PostfixExpression expression) {
-        expression.left.Declarator
+        expression.operand.Declarator
     }
 
     def dispatch Declarator Declarator(EObject object) {

--- a/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
@@ -1,6 +1,5 @@
 package com.minres.coredsl.services.visualization
 
-import com.minres.coredsl.coreDsl.Assignment
 import com.minres.coredsl.coreDsl.AssignmentExpression
 import com.minres.coredsl.coreDsl.Attribute
 import com.minres.coredsl.coreDsl.BitField
@@ -67,6 +66,7 @@ import com.minres.coredsl.coreDsl.CastExpression
 import com.minres.coredsl.coreDsl.ContinueStatement
 import com.minres.coredsl.coreDsl.BreakStatement
 import com.minres.coredsl.coreDsl.ReturnStatement
+import com.minres.coredsl.coreDsl.IntrinsicExpression
 
 class Visualizer {
 	
@@ -484,57 +484,70 @@ class Visualizer {
 		return makeImmediateLiteral(node.value)
 	}
 	
+	private def dispatch VisualNode genNode(AssignmentExpression node) {
+		return makeNode(node, "Assignment Expression",
+			makeChild("Assignment Target", node.target),
+			makeChild("Value", node.value)
+		);
+	}
+	
 	private def dispatch VisualNode genNode(InfixExpression node) {
-		return makeNode(node, "Infix Expression (" + node.op + ")",
+		return makeNode(node, "Infix Expression (" + node.operator + ")",
 			makeChild("Left", node.left),
 			makeChild("Right", node.right)
 		);
 	}
 	
 	private def dispatch VisualNode genNode(PrefixExpression node) {
-		return makeNode(node, "Prefix Expression (" + node.op + ")",
-			makeChild("Operand", node.left)
+		return makeNode(node, "Prefix Expression (" + node.operator + ")",
+			makeChild("Operand", node.operand)
 		);
 	}
 	
 	private def dispatch VisualNode genNode(PostfixExpression node) {
-		return makeNode(node, "Postfix Expression",
-			makeChild("Operand", node.left),
-			makeNamedLiteral("Operator", node.op)
+		return makeNode(node, "Postfix Expression (" + node.operator + ")",
+			makeChild("Operand", node.operand)
 		);
 	}
 	
 	private def dispatch VisualNode genNode(FunctionCallExpression node) {
 		return makeNode(node, "Function Call",
-			makeChild("Target", node.left),
+			makeChild("Target", node.target),
 			makeGroup("Arguments", node.arguments)
 		);
 	}
 	
 	private def dispatch VisualNode genNode(ArrayAccessExpression node) {
 		return makeNode(node, "Array Access",
-			makeChild("Target", node.left),
+			makeChild("Target", node.target),
 			makeChild("Index", node.index)
 		);
 	}
 	
 	private def dispatch VisualNode genNode(MemberAccessExpression node) {
-		return makeNode(node, "Member Access (" + node.op + ")",
-			makeChild("Target", node.left),
+		return makeNode(node, "Member Access (" + node.operator + ")",
+			makeChild("Target", node.target),
 			makeReference("Member", node.declarator?.name, [node.declarator])
 		);
 	}
 	
 	private def dispatch VisualNode genNode(ParenthesisExpression node) {
 		return makeNode(node, "Parenthesis Expression",
-			makeChild("Inner", node.left)
+			makeChild("Inner", node.inner)
 		);
 	}
 	
 	private def dispatch VisualNode genNode(CastExpression node) {
 		return makeNode(node, "Cast Expression",
-			makeChild("Target Type", node.type),
-			makeChild("Operand", node.left)
+			makeChild("Target Type", node.targetType),
+			makeChild("Operand", node.operand)
+		);
+	}
+	
+	private def dispatch VisualNode genNode(IntrinsicExpression node) {
+		return makeNode(node, "Intrinsic Function Call",
+			makeNamedLiteral("Function", node.function),
+			makeGroup("Arguments", node.arguments)
 		);
 	}
 	
@@ -547,15 +560,5 @@ class Visualizer {
 			
 		if(node.target instanceof BitField)
 			return makeNode(node, "Field Reference", makeReference("Field", (node.target as BitField).name, [node.target]));
-	}
-	
-	private def dispatch VisualNode genNode(AssignmentExpression node) {
-		return makeNode(node, "Assignment Expression", node.assignments);
-	}
-	
-	private def dispatch VisualNode genNode(Assignment node) {
-		return makeNode(node, "Assignment (" + node.type + ")",
-			makeChild("Value", node.right)
-		);
 	}
 }

--- a/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
@@ -137,15 +137,15 @@ class TypeProvider {
     }
 
     def static dispatch DataType typeFor(AssignmentExpression e, ISA ctx) {
-        return e.assignments.last.right.typeFor(ctx)
+        return e.value.typeFor(ctx)
     }
 
     def static dispatch DataType typeFor(ConditionalExpression e, ISA ctx) {
-        return e.left.typeFor(ctx)
+        return e.thenExpression.typeFor(ctx)
     }
 
     def static dispatch DataType typeFor(InfixExpression e, ISA ctx) {
-        switch(e.op){
+        switch(e.operator){
             case "||", case "&&", 
             case "==", case "!=", case "<", case ">", case "<=", case ">=": boolType
             case '|', case "&", case "^": {
@@ -172,31 +172,30 @@ class TypeProvider {
     }
 
     def static dispatch DataType typeFor(CastExpression e, ISA ctx) {
-        return e.type.typeFor(ctx)
+        return e.targetType.typeFor(ctx)
     }
 
     def static dispatch DataType typeFor(PrefixExpression e, ISA ctx) {
-        switch(e.op){
+        switch(e.operator){
             case "++",
-            case "--": e.left.typeFor(ctx)
-            case "~": e.left.typeFor(ctx)
+            case "--",
+            case "~": e.operand.typeFor(ctx)
             case "!": boolType
-            case "sizeof": new DataType(DataType.Type.INTEGRAL_UNSIGNED, 32)
-            default: // missing 'case "&", case "*", case "+" , case "-":'
+            default:
                 null
         }
     }
 
     def static dispatch DataType typeFor(PostfixExpression e, ISA ctx) {
-        return e.left.typeFor(ctx);
+        return e.operand.typeFor(ctx);
     }
 
     def static dispatch DataType typeFor(FunctionCallExpression e, ISA ctx) {
-        return e.left.typeFor(ctx);
+        null
     }
 
     def static dispatch DataType typeFor(ArrayAccessExpression e, ISA ctx) {
-        return e.left.typeFor(ctx);
+        return e.target.typeFor(ctx);
     }
 
     def static dispatch DataType typeFor(MemberAccessExpression e, ISA ctx) {
@@ -204,7 +203,7 @@ class TypeProvider {
     }
 
     def static dispatch DataType typeFor(ParenthesisExpression e, ISA ctx) {
-        return e.left.typeFor(ctx);
+        return e.inner.typeFor(ctx);
     }
     
     def static dispatch DataType typeFor(EntityReference e, ISA ctx) {

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/CoreDslValidator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/CoreDslValidator.xtend
@@ -53,7 +53,7 @@ class CoreDslValidator extends AbstractCoreDslValidator {
 					error(
 						"incompatible types used",
 						// TODO this doesn't necessarily make sense as a location
-						CoreDslPackage.Literals.EXPRESSION__LEFT,
+						null,
 						TYPE_MISMATCH
 					)
 			case CastExpression: {
@@ -73,7 +73,7 @@ class CoreDslValidator extends AbstractCoreDslValidator {
 					case '>=',
 					case '==',
 					case '!=':
-						if (!e.left.typeFor.isComparable((e as InfixExpression).right.typeFor))
+						if (!infix.left.typeFor.isComparable(infix.right.typeFor))
 							error(
 								"incompatible types used",
 								CoreDslPackage.Literals.INFIX_EXPRESSION__OP,
@@ -91,7 +91,7 @@ class CoreDslValidator extends AbstractCoreDslValidator {
 					case '|',
 					case '^',
 					case '&':
-						if (!e.left.typeFor.isComputable((e as InfixExpression).right.typeFor))
+						if (!infix.left.typeFor.isComputable(infix.right.typeFor))
 							error(
 								"incompatible types used",
 								CoreDslPackage.Literals.INFIX_EXPRESSION__OP,

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/CoreDslValidator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/CoreDslValidator.xtend
@@ -57,16 +57,16 @@ class CoreDslValidator extends AbstractCoreDslValidator {
 						TYPE_MISMATCH
 					)
 			case CastExpression: {
-				if ((e as CastExpression).type.typeFor === null)
+				if ((e as CastExpression).targetType.typeFor === null)
 					error(
 						"illegal type used",
-						CoreDslPackage.Literals.CAST_EXPRESSION__TYPE,
+						CoreDslPackage.Literals.CAST_EXPRESSION__TARGET_TYPE,
 						TYPE_ILLEGAL
 					)
 			}
 			case InfixExpression: {
 				val infix = e as InfixExpression
-				switch (infix.op) {
+				switch (infix.operator) {
 					case '<',
 					case '>',
 					case '<=',
@@ -76,7 +76,7 @@ class CoreDslValidator extends AbstractCoreDslValidator {
 						if (!infix.left.typeFor.isComparable(infix.right.typeFor))
 							error(
 								"incompatible types used",
-								CoreDslPackage.Literals.INFIX_EXPRESSION__OP,
+								CoreDslPackage.Literals.INFIX_EXPRESSION__OPERATOR,
 								TYPE_MISMATCH
 							)
 					case '||',
@@ -94,7 +94,7 @@ class CoreDslValidator extends AbstractCoreDslValidator {
 						if (!infix.left.typeFor.isComputable(infix.right.typeFor))
 							error(
 								"incompatible types used",
-								CoreDslPackage.Literals.INFIX_EXPRESSION__OP,
+								CoreDslPackage.Literals.INFIX_EXPRESSION__OPERATOR,
 								TYPE_MISMATCH
 							)
 					default: {


### PR DESCRIPTION
Depends on #42.
Implements suggestion 3 from #34 as well as suggestions 7, 8, and 9 from #38.

Diff without the changes from #42: https://github.com/Minres/CoreDSL/compare/1e7e1f4...aa8ae84

## Structure Changes
- Replaced `ConditionalExpression` with `Expression` in many places
- Integrated `AssignmentExpression` into the precedence hierarchy (above `ConditionalExpression`)
- Fixed associativity for all infix expressions
- Changed `ConcatenationExpression` to be parsed as a flat list
- Added `IntrinsicExpression` for intrinsic functions like `sizeof`
- Added support for multiple nested prefix expressions: `~+-x` is now valid

## Name Changes
| Old Class | Old Field				| New Class | New Field |
|---|---|---|---|
|`AssignmentExpression`|`left`			|`AssignmentExpression`|`target`|
|`AssignmentExpression`|`right`		|`AssignmentExpression`|`value`|
|`ConditionalExpression`|`cond`		|`ConditionalExpression`|`condition`|
|`ConditionalExpression`|`left`			|`ConditionalExpression`|`thenExpression`|
|`ConditionalExpression`|`right`		|`ConditionalExpression`|`elseExpression`|
|`InfixExpression`|`op`				|`InfixExpression`|`operator`|
|`PrefixExpression`|`op`				|`PrefixExpression`|`operator`|
|`PostfixExpression`|`op`				|`PostfixExpression`|`operator`|
|`MemberAccessExpression`|`op`		|`MemberAccessExpression`|`operator`|
|`PrefixExpression`|`left`				|`PrefixExpression`|`operand`|
|`PostfixExpression`|`left`				|`PostfixExpression`|`operand`|
|`CastExpression`|`type`				|`CastExpression`|`targetType`|
|`CastExpression`|`left`				|`CastExpression`|`operand`|
|`FunctionCallExpression`|`left`		|`FunctionCallExpression`|`target`|
|`ArrayAccessExpression`|`left`			|`ArrayAccessExpression`|`target`|
|`MemberAccessExpression`|`left`		|`MemberAccessExpression`|`target`|
|`ParenthesisExpression`|`left`			|`ParenthesisExpression`|`inner`|