### PR TITLE
[Grammar] Types

### DIFF
--- a/com.minres.coredsl.ui/src/com/minres/coredsl/ui/labeling/CoreDslLabelProvider.xtend
+++ b/com.minres.coredsl.ui/src/com/minres/coredsl/ui/labeling/CoreDslLabelProvider.xtend
@@ -59,8 +59,8 @@ class CoreDslLabelProvider extends DefaultEObjectLabelProvider {
     }
 		
 	private def dispatch String getToText(BitField field){
-	    if(field.left !== null && field.right !== null)
-            field.name + "[" + field.left.value.intValue + ":" + field.right.value.intValue + "]"
+	    if(field.startIndex !== null && field.endIndex!== null)
+            field.name + "[" + field.startIndex.value.intValue + ":" + field.endIndex.value.intValue + "]"
 	    else
 		    field.name
 	}

--- a/com.minres.coredsl.ui/src/com/minres/coredsl/ui/outline/CoreDslOutlineTreeProvider.xtend
+++ b/com.minres.coredsl.ui/src/com/minres/coredsl/ui/outline/CoreDslOutlineTreeProvider.xtend
@@ -46,8 +46,8 @@ class CoreDslOutlineTreeProvider extends DefaultOutlineTreeProvider {
 
 	def void _createChildren(IOutlineNode parentNode, CoreDef modelElement) {
 		val image = imageDispatcher.invoke(modelElement.declarations)
-		if(modelElement.contributingType.size>0)
-      	createEStructuralFeatureNode(parentNode, modelElement, CoreDslPackage.Literals.CORE_DEF__CONTRIBUTING_TYPE, 
+		if(modelElement.providedInstructionSets.size>0)
+      	createEStructuralFeatureNode(parentNode, modelElement, CoreDslPackage.Literals.CORE_DEF__PROVIDED_INSTRUCTION_SETS, 
 	        image, "Contributing", false)
 		if(modelElement.declarations.size>0)
 		createEStructuralFeatureNode(parentNode, modelElement, CoreDslPackage.Literals.ISA__DECLARATIONS,

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -111,19 +111,13 @@ Declarator<allowInit>:
 	name=ID
 	(LEFT_BR dimensions+=Expression RIGHT_BR)*
 	attributes+=Attribute*
-	(<allowInit> t_equals='=' initializer=(ExpressionInitializer | ListInitializer))?;
+	(<allowInit> t_equals='=' initializer=Initializer)?;
 
 NamedEntity: FunctionDefinition | Declarator<true> | BitField;
     
-Initializer: ExpressionInitializer | ListInitializer | DesignatedInitializer;
-
-ExpressionInitializer: expr=Expression;
-
+Initializer: ExpressionInitializer | ListInitializer;
+ExpressionInitializer: value=Expression;
 ListInitializer: '{' initializers+=Initializer (',' initializers+=Initializer)* ','? '}';
-
-DesignatedInitializer: (designators+=Designator)+ '=' initializer=(ExpressionInitializer | ListInitializer);
-
-Designator: LEFT_BR idx=Expression RIGHT_BR | '.' prop=ID;
 
 Attribute:
 	DoubleLeftBracket type=ID

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -9,47 +9,34 @@ generate coreDsl "http://www.minres.com/coredsl/CoreDsl/2.0"
 ///////////////////////////////////////////////////////////////////////////////////////
 
 DescriptionContent: (imports+=Import)* definitions+=(InstructionSet | CoreDef)+;
-
 Import: 'import' importURI=STRING;
 
 InstructionSet : 'InstructionSet' name=ID ( 'extends' superType=[InstructionSet] )? '{' ISA '}';
-
-CoreDef: 'Core' name=ID ( 'provides' contributingType+=[InstructionSet] (',' contributingType+=[InstructionSet])*)? '{' ISA '}';
+CoreDef: 'Core' name=ID ( 'provides' providedInstructionSets+=[InstructionSet] (',' providedInstructionSets+=[InstructionSet])*)? '{' ISA '}';
 
 fragment ISA:
-	('architectural_state' '{' (declarations+=DeclarationStatement | assignments+=ExpressionStatement)+ '}')? &
+	('architectural_state' '{' (declarations+=DeclarationStatement | assignments+=ExpressionStatement | types+=UserTypeDeclaration)+ '}')? &
 	('functions' '{' functions+=FunctionDefinition+ '}')? &
 	('instructions' commonInstructionAttributes+=Attribute* '{' instructions+=Instruction+ '}')?;
+
+FunctionDefinition:
+	extern?='extern'?
+	returnType=TypeSpecifier name=ID
+	'(' (parameters+=ParameterDeclaration (',' parameters+=ParameterDeclaration)*)? ')'
+	attributes+=Attribute*
+	body=CompoundStatement;
 
 Instruction:
 	name=ID attributes+=Attribute* '{' 
 		('encoding' ':' encoding=Encoding ';')
 		('assembly' ':' assembly=STRING ';')?
 		('behavior' ':' behavior=Statement)
-	'}'
-;
+	'}';
 
-Encoding
-	:	fields+=Field ('::' fields+=Field)*
-	;
-
-Field
-	: 	BitValue
-	|	BitField
-	;
-
-BitValue
-	: 	value=INTEGER
-	;
-
-BitField
-	:	name=ID LEFT_BR left=IntegerConstant ':' right=IntegerConstant RIGHT_BR 
-	;
-
-FunctionDefinition
-	:   extern?='extern' type=TypeSpecifier name=ID '(' (parameters+=ParameterDeclaration (',' parameters+=ParameterDeclaration)*)? ')' ';'
-	|   type=TypeSpecifier name=ID '(' (parameters+=ParameterDeclaration (',' parameters+=ParameterDeclaration)*)? ')' attributes+=Attribute* body=CompoundStatement
-	;
+Encoding: fields+=EncodingField ('::' fields+=EncodingField)*;
+EncodingField: BitValue | BitField;
+BitValue: value=INTEGER;
+BitField: name=ID LEFT_BR startIndex=IntegerConstant ':' endIndex=IntegerConstant RIGHT_BR;
 
 ////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Statements ////////////////////////////////
@@ -143,54 +130,34 @@ Attribute:
 	('=' parameters+=Expression | '(' parameters+=Expression (',' parameters+=Expression)* ')')?
 	DoubleRightBracket;
 
+//////////////////////////////// Type Declarations ////////////////////////////////
+
+UserTypeDeclaration: StructTypeDeclaration | UnionTypeDeclaration | EnumTypeDeclaration;
+
+StructTypeDeclaration: 'struct' name=ID CompositeTypeDeclaration;
+UnionTypeDeclaration: 'union' name=ID CompositeTypeDeclaration;
+EnumTypeDeclaration: 'enum' name=ID '{' members+=EnumMemberDeclaration (',' members+=EnumMemberDeclaration)* ','? '}';
+
+EnumMemberDeclaration: name=ID ('=' value=Expression)?;
+
+fragment CompositeTypeDeclaration: '{' (members+=MultiDeclaration ';')* '}';
+
 //////////////////////////////// Type Specifiers ////////////////////////////////
 
-TypeSpecifier
-	:	ValueTypeSpecifier
-	|	VoidTypeSpecifier
-	;
+TypeSpecifier: VoidTypeSpecifier | PrimitiveTypeSpecifier | UserTypeSpecifier;
 
-ValueTypeSpecifier
-	:	PrimitiveTypeSpecifier
-	|	CompositeTypeSpecifier
-	|	EnumTypeSpecifier
-	;
+PrimitiveTypeSpecifier: IntegerTypeSpecifier | FloatTypeSpecifier | BoolTypeSpecifier;
 
-PrimitiveTypeSpecifier
-	:	IntegerTypeSpecifier
-	|	FloatTypeSpecifier
-	|	BoolTypeSpecifier
-	;
+IntegerTypeSpecifier: shorthand=IntegerSizeShorthand | signedness=IntegerSignedness (shorthand=IntegerSizeShorthand | '<' size=PrimaryExpression '>');
+FloatTypeSpecifier: shorthand=FloatSizeShorthand;
+BoolTypeSpecifier: {BoolTypeSpecifier} 'bool';
+VoidTypeSpecifier: {VoidTypeSpecifier} 'void';
 
-IntegerTypeSpecifier
-	:	signedness=IntegerSignedness (shorthand=IntegerSizeShorthand | '<' size=PrimaryExpression '>')
-	|	shorthand=IntegerSizeShorthand
-	;
-
-FloatTypeSpecifier
-	:	shorthand=FloatSizeShorthand;
-
-BoolTypeSpecifier
-	:	{BoolTypeSpecifier} 'bool';
-
-VoidTypeSpecifier
-	:	{VoidTypeSpecifier} 'void';
-
-CompositeTypeSpecifier
-    :   composeType=StructOrUnion name=ID? '{' (declarations+=MultiDeclaration ';')* '}'
-    |   composeType=StructOrUnion name=ID
-    ;
+UserTypeSpecifier: StructTypeSpecifier | UnionTypeSpecifier | EnumTypeSpecifier;
 	
-// TODO add optional size specifier after name? (':' size=IntegerTypeSpecifier)?
-EnumTypeSpecifier
-    :   'enum' name=ID? '{' enumerators+=EnumMemberDeclaration (',' enumerators+=EnumMemberDeclaration)* ','? '}'
-    |   'enum' name=ID
-    ;
-
-EnumMemberDeclaration
-    :   name=ID
-    |   name=ID '=' expression=Expression
-    ;
+StructTypeSpecifier: 'struct' target=[StructTypeDeclaration];
+UnionTypeSpecifier: 'union' target=[UnionTypeDeclaration];
+EnumTypeSpecifier: 'enum' target=[EnumTypeDeclaration];
 
 /////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Expressions ////////////////////////////////
@@ -242,12 +209,12 @@ PrefixExpression returns Expression:
 
 PostfixExpression returns Expression:
 	PrimaryExpression
-	(	{FunctionCallExpression.target=current} '(' (arguments+=Expression (',' arguments+=Expression)*)? ')'
-	|	{ArrayAccessExpression.target=current} LEFT_BR index=Expression (':' endIndex=Expression)? RIGHT_BR
-	|	{MemberAccessExpression.target=current} operator='.' declarator=[Declarator]
-	|	{MemberAccessExpression.target=current} operator='->' declarator=[Declarator]
-	|	{PostfixExpression.operand=current} operator='++'
-	|	{PostfixExpression.operand=current} operator='--'
+	( {FunctionCallExpression.target=current} '(' (arguments+=Expression (',' arguments+=Expression)*)? ')'
+	| {ArrayAccessExpression.target=current} LEFT_BR index=Expression (':' endIndex=Expression)? RIGHT_BR
+	| {MemberAccessExpression.target=current} operator='.' declarator=[Declarator]
+	| {MemberAccessExpression.target=current} operator='->' declarator=[Declarator]
+	| {PostfixExpression.operand=current} operator='++'
+	| {PostfixExpression.operand=current} operator='--'
 	)*;
 
 PrimaryExpression: ParenthesisExpression | EntityReference | IntrinsicExpression | Constant;
@@ -281,16 +248,11 @@ StringLiteral: value=ENCSTRINGCONST | value=STRING ;
 //////////////////////////////////////////////////////////////////////////////
 
 enum IntegerSignedness : SIGNED='signed' | UNSIGNED='unsigned';
-
 enum IntegerSizeShorthand : INT='int' | CHAR='char' | SHORT='short' |  LONG='long';
-
 enum FloatSizeShorthand : FLOAT='float' | DOUBLE='double';
 
 enum TypeQualifier: CONST='const' | VOLATILE='volatile';
-
 enum StorageClassSpecifier: EXTERN='extern' | STATIC='static' | REGISTER='register';
-
-enum StructOrUnion:   STRUCT='struct'|UNION='union';
 
 ////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Terminal Rules ////////////////////////////////

--- a/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
@@ -47,7 +47,7 @@ class CoreDSLInterpreter {
             val context = ctx.definitionContext
             if (context === null) {
                 if (decl.initializer instanceof ExpressionInitializer)
-                    return (decl.initializer as ExpressionInitializer).expr.valueFor(ctx)
+                    return (decl.initializer as ExpressionInitializer).value.valueFor(ctx)
                 else
                     return null
             }
@@ -62,7 +62,7 @@ class CoreDSLInterpreter {
             ].last
             if (declAssignment === null) {
                 if (decl.initializer instanceof ExpressionInitializer)
-                    return (decl.initializer as ExpressionInitializer).expr.valueFor(ctx)
+                    return (decl.initializer as ExpressionInitializer).value.valueFor(ctx)
                 else
                     return null
             } else
@@ -215,7 +215,7 @@ class CoreDSLInterpreter {
         if (e.initializer !== null) {
             if (e.initializer instanceof ExpressionInitializer) {
                 val initializer = e.initializer as ExpressionInitializer;
-                return ctx.newValue(e, initializer.expr.valueFor(ctx))
+                return ctx.newValue(e, initializer.value.valueFor(ctx))
             } else if (e.eContainer.eContainer.eContainer instanceof ISA) {
                 val directDecl = ctx.definitionContext.effectiveDeclarator(e.name)
                 return directDecl.evaluate(ctx);

--- a/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/interpreter/CoreDSLInterpreter.xtend
@@ -182,7 +182,7 @@ class CoreDSLInterpreter {
     }
 
     def static dispatch Value valueFor(FunctionDefinition e, EvaluationContext ctx) {
-        e.type.valueFor(ctx)
+        e.returnType.valueFor(ctx)
     }
 
     def static dispatch Value valueFor(Declarator e, EvaluationContext ctx) {
@@ -225,7 +225,7 @@ class CoreDSLInterpreter {
     }
 
     def static dispatch Value valueFor(BitField e, EvaluationContext ctx) {
-        new Value(new DataType(DataType.Type.INTEGRAL_UNSIGNED, e.left.value.intValue), null) // bitfield cannot be evaluated
+        new Value(new DataType(DataType.Type.INTEGRAL_UNSIGNED, e.endIndex.value.intValue - e.startIndex.value.intValue + 1), null) // bitfield cannot be evaluated
     }
 
     def static dispatch Value valueFor(BitValue e, EvaluationContext ctx) {

--- a/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
@@ -9,8 +9,6 @@ import com.minres.coredsl.coreDsl.CompoundStatement
 import com.minres.coredsl.coreDsl.CoreDef
 import com.minres.coredsl.coreDsl.Declaration
 import com.minres.coredsl.coreDsl.DescriptionContent
-import com.minres.coredsl.coreDsl.DesignatedInitializer
-import com.minres.coredsl.coreDsl.Designator
 import com.minres.coredsl.coreDsl.Declarator
 import com.minres.coredsl.coreDsl.Encoding
 import com.minres.coredsl.coreDsl.ExpressionStatement
@@ -462,27 +460,11 @@ class Visualizer {
 	}
 	
 	private def dispatch VisualNode genNode(ExpressionInitializer node) {
-		return visit(node.expr);
+		return visit(node.value);
 	}
 	
 	private def dispatch VisualNode genNode(ListInitializer node) {
-		return makeNode(node, "List Initializer",
-			makeGroup("", node.initializers)
-		);
-	}
-	
-	private def dispatch VisualNode genNode(DesignatedInitializer node) {
-		return makeNode(node, "Designated Initializer",
-			makeGroup("Designators", node.designators),
-			makeChild("Initializer", node.initializer)
-		);
-	}
-	
-	private def dispatch VisualNode genNode(Designator node) {
-		return makeNode(node, "Designator",
-			makeChild("Index", node.idx),
-			makeNamedLiteral("Property", node.prop)
-		);
+		return makeNode(node, "List Initializer", node.initializers);
 	}
 	
 	// expressions

--- a/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/services/visualization/Visualizer.xtend
@@ -26,7 +26,6 @@ import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
 import com.minres.coredsl.coreDsl.SpawnStatement
 import com.minres.coredsl.coreDsl.StringLiteral
-import com.minres.coredsl.coreDsl.StructOrUnion
 import com.minres.coredsl.coreDsl.SwitchStatement
 import com.minres.coredsl.services.visualization.VisualElement.DeclarationLiteral
 import com.minres.coredsl.services.visualization.VisualElement.Literal
@@ -45,7 +44,6 @@ import org.eclipse.emf.ecore.EObject
 import com.minres.coredsl.coreDsl.FunctionCallExpression
 import com.minres.coredsl.coreDsl.ArrayAccessExpression
 import com.minres.coredsl.coreDsl.MemberAccessExpression
-import com.minres.coredsl.coreDsl.CompositeTypeSpecifier
 import com.minres.coredsl.coreDsl.EnumTypeSpecifier
 import com.minres.coredsl.coreDsl.BoolTypeSpecifier
 import com.minres.coredsl.coreDsl.VoidTypeSpecifier
@@ -67,6 +65,12 @@ import com.minres.coredsl.coreDsl.ContinueStatement
 import com.minres.coredsl.coreDsl.BreakStatement
 import com.minres.coredsl.coreDsl.ReturnStatement
 import com.minres.coredsl.coreDsl.IntrinsicExpression
+import com.minres.coredsl.coreDsl.StructTypeSpecifier
+import com.minres.coredsl.coreDsl.UnionTypeSpecifier
+import com.minres.coredsl.coreDsl.EnumTypeDeclaration
+import com.minres.coredsl.coreDsl.StructTypeDeclaration
+import com.minres.coredsl.coreDsl.UnionTypeDeclaration
+import com.minres.coredsl.coreDsl.EnumMemberDeclaration
 
 class Visualizer {
 	
@@ -205,7 +209,7 @@ class Visualizer {
 		return makeNode(node, "Core Description",
 			makeGroup("Imports", node.imports),
 			makeGroup("Definitions", node.definitions)
-		)
+		);
 	}
 	
 	private def dispatch VisualNode genNode(Import node) {
@@ -219,8 +223,10 @@ class Visualizer {
 			makeNamedLiteral("Name", node.name),
 			makeNamedLiteral("Super Type", node.superType?.name),
 			makeGroup("Declarations", node.declarations),
+			makeGroup("Assignments", node.assignments),
+			makeGroup("Types", node.types),
 			makeGroup("Functions", node.functions),
-			makeGroup("Attributes", node.commonInstructionAttributes),
+			makeGroup("Instruction Attributes", node.commonInstructionAttributes),
 			makeGroup("Instructions", node.instructions)
 		);
 	}
@@ -228,12 +234,14 @@ class Visualizer {
 	private def dispatch VisualNode genNode(CoreDef node) {
 		return makeNode(node, "Instruction Set",
 			makeNamedLiteral("Name", node.name),
-			makeGroup("Contributing Type", node.contributingType),
+			makeGroup("Provided Instruction Sets", node.providedInstructionSets),
 			makeGroup("Declarations", node.declarations),
+			makeGroup("Assignments", node.assignments),
+			makeGroup("Types", node.types),
 			makeGroup("Functions", node.functions),
-			makeGroup("Attributes", node.commonInstructionAttributes),
+			makeGroup("Instruction Attributes", node.commonInstructionAttributes),
 			makeGroup("Instructions", node.instructions)
-		)
+		);
 	}
 	
 	private def dispatch VisualNode genNode(Instruction node) {
@@ -252,31 +260,24 @@ class Visualizer {
 	private def dispatch VisualNode genNode(BitField node) {
 		return makeNode(node, "Bit Field",
 			makeNamedLiteral("Name", node.name),
-			makeChild("Left", node.left),
-			makeChild("Right", node.right)
-		)
+			makeChild("StartIndex", node.startIndex),
+			makeChild("EndIndex", node.endIndex)
+		);
 	}
 	
 	private def dispatch VisualNode genNode(BitValue node) {
 		return makeNode(node, "Bit Value",
 			makeNamedLiteral("Value", node.value.toString)
-		)
+		);
 	}
 	
 	private def dispatch VisualNode genNode(FunctionDefinition node) {
-		return node.extern
-		? makeNode(node, "Function (extern)",
-			makeChild("Return Type", node.type),
+		return makeNode(node, node.extern ? "Function (extern)" : "Function",
+			makeChild("Return Type", node.returnType),
 			makeNamedLiteral("Name", node.name),
 			makeGroup("Parameters", node.parameters),
-			makeGroup("Attributes", node.attributes)
-		)
-		: makeNode(node, "Function",
-			makeChild("Return Type", node.type),
-			makeNamedLiteral("Name", node.name),
-			makeGroup("Parameters", node.parameters),
-			makeChild("Body", node.body),
-			makeGroup("Attributes", node.attributes)
+			makeGroup("Attributes", node.attributes),
+			makeChild("Body", node.body)
 		);
 	}
 	
@@ -405,18 +406,50 @@ class Visualizer {
 		);
 	}
 	
-	private def dispatch VisualNode genNode(CompositeTypeSpecifier node) {
-		return makeNode(node, node.composeType == StructOrUnion.STRUCT ? "Struct Type" : "Union Type",
-			makeNamedLiteral("Name", node.name),
-			makeGroup("Declarations", node.declarations)
-		)
+	private def dispatch VisualNode genNode(StructTypeSpecifier node) {
+		return makeNode(node, "Struct Type",
+			makeReference("Target", node.target?.name, [node.target])
+		);
+	}
+	
+	private def dispatch VisualNode genNode(UnionTypeSpecifier node) {
+		return makeNode(node, "Union Type",
+			makeReference("Target", node.target?.name, [node.target])
+		);
 	}
 	
 	private def dispatch VisualNode genNode(EnumTypeSpecifier node) {
 		return makeNode(node, "Enum Type",
-			makeNamedLiteral("Name", node.name),
-			makeGroup("Members", node.enumerators)
-		)
+			makeReference("Target", node.target?.name, [node.target])
+		);
+	}
+	
+	private def dispatch VisualNode genNode(StructTypeDeclaration node) {
+		return makeNode(node, "Struct Type Declaration",
+			makeDeclaration("Name", node.name, node),
+			makeGroup("Members", node.members)
+		);
+	}
+	
+	private def dispatch VisualNode genNode(UnionTypeDeclaration node) {
+		return makeNode(node, "Union Type Declaration",
+			makeDeclaration("Name", node.name, node),
+			makeGroup("Members", node.members)
+		);
+	}
+	
+	private def dispatch VisualNode genNode(EnumTypeDeclaration node) {
+		return makeNode(node, "Enum Type Declaration",
+			makeDeclaration("Name", node.name, node),
+			makeGroup("Members", node.members)
+		);
+	}
+	
+	private def dispatch VisualNode genNode(EnumMemberDeclaration node) {
+		return makeNode(node, "Enum Member",
+			makeDeclaration("Name", node.name, node),
+			makeChild("Value", node.value)
+		);
 	}
 	
 	private def dispatch VisualNode genNode(Declarator node) {
@@ -455,19 +488,19 @@ class Visualizer {
 	// expressions
 	
 	private def dispatch VisualNode genNode(IntegerConstant node) {
-		return makeImmediateLiteral(node.value.toString)
+		return makeImmediateLiteral(node.value.toString);
 	}
 	
 	private def dispatch VisualNode genNode(FloatConstant node) {
-		return makeImmediateLiteral(node.value.toString)
+		return makeImmediateLiteral(node.value.toString);
 	}
 	
 	private def dispatch VisualNode genNode(BoolConstant node) {
-		return makeImmediateLiteral(node.value.toString)
+		return makeImmediateLiteral(node.value.toString);
 	}
 	
 	private def dispatch VisualNode genNode(CharacterConstant node) {
-		return makeImmediateLiteral(node.value)
+		return makeImmediateLiteral(node.value);
 	}
 	
 	private def dispatch VisualNode genNode(StringConstant node) {
@@ -481,7 +514,7 @@ class Visualizer {
 	}
 	
 	private def dispatch VisualNode genNode(StringLiteral node) {
-		return makeImmediateLiteral(node.value)
+		return makeImmediateLiteral(node.value);
 	}
 	
 	private def dispatch VisualNode genNode(AssignmentExpression node) {

--- a/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/typing/TypeProvider.xtend
@@ -6,7 +6,6 @@ import com.minres.coredsl.coreDsl.BitValue
 import com.minres.coredsl.coreDsl.BoolConstant
 import com.minres.coredsl.coreDsl.CastExpression
 import com.minres.coredsl.coreDsl.CharacterConstant
-import com.minres.coredsl.coreDsl.CompositeTypeSpecifier
 import com.minres.coredsl.coreDsl.ConditionalExpression
 import com.minres.coredsl.coreDsl.Declaration
 import com.minres.coredsl.coreDsl.Declarator
@@ -20,7 +19,6 @@ import com.minres.coredsl.coreDsl.PostfixExpression
 import com.minres.coredsl.coreDsl.PrefixExpression
 import com.minres.coredsl.coreDsl.StringLiteral
 import com.minres.coredsl.coreDsl.Encoding
-import com.minres.coredsl.coreDsl.Field
 import com.minres.coredsl.coreDsl.ISA
 import com.minres.coredsl.coreDsl.TypeSpecifier
 import com.minres.coredsl.coreDsl.Constant
@@ -44,6 +42,8 @@ import com.minres.coredsl.coreDsl.ParenthesisExpression
 import com.minres.coredsl.coreDsl.StringConstant
 import com.minres.coredsl.coreDsl.NamedEntity
 import com.minres.coredsl.coreDsl.EntityReference
+import com.minres.coredsl.coreDsl.UserTypeSpecifier
+import com.minres.coredsl.coreDsl.EncodingField
 
 class TypeProvider {
 
@@ -77,12 +77,12 @@ class TypeProvider {
         e.typeFor(e.parentOfType(ISA))
     }
 
-    def static dispatch DataType typeFor(CompositeTypeSpecifier e, ISA ctx) {
-        return new DataType(DataType.Type.COMPOSITE, 0)
-    }
-
     def static dispatch DataType typeFor(EnumTypeSpecifier e, ISA ctx) {
         return new DataType(DataType.Type.INTEGRAL_SIGNED, 32)
+    }
+
+    def static dispatch DataType typeFor(UserTypeSpecifier e, ISA ctx) {
+        return new DataType(DataType.Type.COMPOSITE, 0)
     }
     
     def static dispatch DataType typeFor(VoidTypeSpecifier e, ISA ctx) {
@@ -215,7 +215,7 @@ class TypeProvider {
     }
 
     def static dispatch DataType typeFor(FunctionDefinition e, ISA ctx) {
-        e.type.typeFor(ctx)
+        e.returnType.typeFor(ctx)
     }
 
     def static dispatch DataType typeFor(Declarator e, ISA ctx) {
@@ -228,16 +228,16 @@ class TypeProvider {
 
     def static dispatch DataType  typeFor(Encoding list, ISA ctx) {
         var size=0
-        for(Field f:list.fields)
+        for(EncodingField f:list.fields)
             switch(f){
-                BitField:{size += f.left.value.intValue-f.right.value.intValue+1}
+                BitField:{size += f.endIndex.value.intValue - f.startIndex.value.intValue + 1}
                 BitValue:{size += (f.value as BigIntegerWithRadix).size}
             }
         new DataType(DataType.Type.INTEGRAL_UNSIGNED, size)
     }
 
     def static dispatch DataType typeFor(BitField e, ISA ctx) {
-        new DataType(DataType.Type.INTEGRAL_UNSIGNED, e.left.value.intValue + 1)
+        new DataType(DataType.Type.INTEGRAL_UNSIGNED, e.endIndex.value.intValue - e.startIndex.value.intValue + 1)
     }
 
     def static dispatch DataType typeFor(BitValue e, ISA ctx) {

--- a/com.minres.coredsl/src/com/minres/coredsl/util/ModelUtil.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/util/ModelUtil.xtend
@@ -68,7 +68,7 @@ class ModelUtil {
             if(decl!==null) {
                 return (decl as Declaration).declarators.findFirst[it.name==name]
             }
-            for(contrib:isa.contributingType.reverseView) {
+            for(contrib:isa.providedInstructionSets.reverseView) {
                 val contribDecl = contrib.effectiveDeclarator(name)
                 if(contribDecl!==null)
                     return contribDecl
@@ -89,10 +89,10 @@ class ModelUtil {
     static def Iterable<Statement> allDefinitions(ISA isa){
         switch(isa){
             CoreDef:
-                if (isa.contributingType.size == 0)
+                if (isa.providedInstructionSets.size == 0)
                     return isa.declarations + isa.assignments
                 else {
-                    val instrSets = isa.contributingType?.flatMap[it.allInstructionSets]
+                    val instrSets = isa.providedInstructionSets?.flatMap[it.allInstructionSets]
                     val seen = newLinkedHashSet
                     seen.addAll(instrSets)
                     seen.add(isa)
@@ -105,8 +105,8 @@ class ModelUtil {
     
     static def Iterable<Instruction> allInstr(CoreDef core){
         val unique = newLinkedHashMap
-        val instrList = if(core.contributingType.size == 0) core.instructions else {
-            val instrSets = core.contributingType?.map[InstructionSet i| i.allInstructionSets].flatten
+        val instrList = if(core.providedInstructionSets.size == 0) core.instructions else {
+            val instrSets = core.providedInstructionSets?.map[InstructionSet i| i.allInstructionSets].flatten
             val seen = newLinkedHashSet
             seen.addAll(instrSets)
             seen.add(core)
@@ -134,7 +134,7 @@ class ModelUtil {
     }
     
     private static def String getBitEncoding(Encoding encoding) '''«FOR field : encoding.fields»«field.regEx»«ENDFOR»'''
-    private static def dispatch getRegEx(BitField i) '''«FOR idx : i.right.value.intValue .. i.left.value.intValue».«ENDFOR»'''
+    private static def dispatch getRegEx(BitField i) '''«FOR idx : i.endIndex.value.intValue .. i.startIndex.value.intValue».«ENDFOR»'''
     private static def dispatch getRegEx(BitValue i) '''«i.value.toString(2)»'''
     
 }


### PR DESCRIPTION
Implements suggestions 10, 11, and 12 from #39 and fixes #23.

## Structure Changes
- User types can no longer be defined within a type specifier
  - They are instead declared within the `architectural_state` section
  - 6 relevant classes: `{Struct|Union|Enum}TypeSpecifier` pointing to `{Struct|Union|Enum}TypeDeclaration`
- Simplified function declaration grammar
  - It is now syntactically valid to specify `extern` on a function with body, or omit the body of a non-extern function
  - Attributes are now valid on extern functions
- Removed support for designated initializers

## Name Changes
| Old Class | Old Field				| New Class | New Field |
|---|---|---|---|
|`CoreDef`|`contributingType`			|`CoreDef`|`providedInstructionSets`|
|`FunctionDefinition`|`type`			|`FunctionDefinition`|`returnType`|
|`ExpressionInitializer`|`expr`			|`ExpressionInitializer`|`value`|
|`BitField`|`left`						|`BitField`|`startIndex`|
|`BitField`|`right`					|`BitField`|`endIndex`|
|`Field`|							|`EncodingField`| |