### PR TITLE
Basic analysis framework

### DIFF
--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/AnalysisContext.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/AnalysisContext.xtend
@@ -1,0 +1,33 @@
+package com.minres.coredsl.analysis
+
+import com.minres.coredsl.coreDsl.CoreDef
+import com.minres.coredsl.coreDsl.ISA
+import com.minres.coredsl.coreDsl.InstructionSet
+import java.util.ArrayList
+import java.util.HashMap
+import java.util.List
+import java.util.Map
+import java.util.Stack
+import org.eclipse.xtext.validation.ValidationMessageAcceptor
+
+class AnalysisContext {
+	public val ISA root;
+	public val ValidationMessageAcceptor acceptor;
+
+	public val CoreDef core;
+
+	public val Stack<InstructionSet> currentInheritanceStack = new Stack;
+	public val List<ISA> elaborationOrder = new ArrayList;
+
+	public val Map<String, CoreDslElaborator.ConstantDefinitionInfo> constantDefinitions = new HashMap;
+
+	new(ISA root, ValidationMessageAcceptor acceptor) {
+		this.root = root;
+		this.core = root instanceof CoreDef ? root : null;
+		this.acceptor = acceptor;
+	}
+
+	def boolean isPartialAnalysis() {
+		return core === null;
+	}
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/ConstantValue.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/ConstantValue.xtend
@@ -1,0 +1,34 @@
+package com.minres.coredsl.analysis
+
+import java.math.BigInteger
+import org.eclipse.xtend.lib.annotations.Data
+
+@Data
+final class ConstantValue {
+	public static val ConstantValue indeterminate = new ConstantValue(StatusCode.indeterminate);
+	public static val ConstantValue invalid = new ConstantValue(StatusCode.invalid);
+
+	public val StatusCode status;
+	public val BigInteger value;
+
+	new(BigInteger value) {
+		this.status = StatusCode.success;
+		this.value = value;
+	}
+
+	private new(StatusCode error) {
+		this.status = error;
+		this.value = null;
+	}
+
+	def isValid() { return status === StatusCode.success; }
+	def isError() { return status !== StatusCode.success; }
+	def isIndeterminate() { return status === StatusCode.indeterminate; }
+	def isInvalid() { return status === StatusCode.invalid; }
+
+	enum StatusCode {
+		success,
+		indeterminate,
+		invalid
+	}
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
@@ -1,0 +1,5 @@
+package com.minres.coredsl.analysis
+
+class CoreDslAnalyzer {
+	
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslConstantExpressionEvaluator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslConstantExpressionEvaluator.xtend
@@ -1,0 +1,116 @@
+package com.minres.coredsl.analysis
+
+import com.minres.coredsl.coreDsl.ConditionalExpression
+import com.minres.coredsl.coreDsl.EntityReference
+import com.minres.coredsl.coreDsl.Expression
+import com.minres.coredsl.coreDsl.ISA
+import com.minres.coredsl.coreDsl.InfixExpression
+import com.minres.coredsl.coreDsl.IntegerConstant
+import com.minres.coredsl.coreDsl.IntrinsicExpression
+import com.minres.coredsl.coreDsl.TypeSpecifier
+import com.minres.coredsl.validation.IssueCodes
+import java.math.BigInteger
+
+import static extension com.minres.coredsl.util.ModelUtil.*
+
+class CoreDslConstantExpressionEvaluator {
+	private new() {}
+
+	static def dispatch ConstantValue evaluate(AnalysisContext ctx, Expression node) {
+		
+		if(node.parentOfType(ISA) == ctx.root) {
+			ctx.acceptor.acceptError(
+				node.class.simpleName + ' is not allowed in constant expression',
+				node.eContainer, node.eContainingFeature,
+				-1, IssueCodes.InvalidConstantExpressionNode);
+		}
+		
+		return ConstantValue.invalid;
+	}
+
+	static def dispatch ConstantValue evaluate(AnalysisContext ctx, EntityReference node) {
+		val value = ctx.constantDefinitions.get(node.target.name).calculatedValue;
+		if (value !== null) return value;
+		return ConstantValue.indeterminate;
+	}
+
+	static def dispatch ConstantValue evaluate(AnalysisContext ctx, IntegerConstant node) {
+		return new ConstantValue(node.value);
+	}
+
+	static def dispatch ConstantValue evaluate(AnalysisContext ctx, IntrinsicExpression node) {
+		switch (node.function) {
+			case "sizeof",
+			case "bitsizeof": {
+				val inBytes = node.function == "sizeof";
+				
+				if (node.arguments.size != 1)
+					return ConstantValue.invalid;
+				
+				val argument = node.arguments.get(0);
+				switch(argument) {
+					
+					TypeSpecifier: {
+						val type = CoreDslTypeProvider.getSpecifiedType(ctx, argument);
+						
+						if(type.invalid) return ConstantValue.invalid;
+						if(type.indeterminate) return ConstantValue.indeterminate;
+						
+						val size = inBytes ? (type.bitSize + 7) / 8 : type.bitSize;
+						return new ConstantValue(BigInteger.valueOf(size));
+					}
+					
+					EntityReference: {
+						val name = argument.target.name;
+						
+						val constant = ctx.constantDefinitions.get(name);
+						if(constant === null) return ConstantValue.invalid;
+						
+						val type = constant.calculatedType; 
+						if(type === null) return ConstantValue.indeterminate;
+						
+						val size = inBytes ? (type.bitSize + 7) / 8 : type.bitSize;
+						return new ConstantValue(BigInteger.valueOf(size));
+					}
+					
+					default: {
+						return ConstantValue.invalid;
+					}
+				}
+			}
+			
+			default: {
+				// TODO
+				return ConstantValue.invalid;
+			}
+		}
+	}
+
+	static def dispatch ConstantValue evaluate(AnalysisContext ctx, InfixExpression node) {
+		val l = evaluate(ctx, node.left);
+		val r = evaluate(ctx, node.right);
+
+		if(l.invalid || r.invalid) return ConstantValue.invalid;
+		if(l.indeterminate || r.indeterminate) return ConstantValue.indeterminate;
+
+		return switch (node.operator) {
+			case '+': new ConstantValue(l.value + r.value)
+			case '-': new ConstantValue(l.value - r.value)
+			case '*': new ConstantValue(l.value * r.value)
+			case '/': new ConstantValue(l.value / r.value)
+			case '%': new ConstantValue(l.value % r.value)
+			default: ConstantValue.invalid
+		}
+	}
+	
+	static def dispatch ConstantValue evaluate(AnalysisContext ctx, ConditionalExpression node) {
+		val condition = evaluate(ctx, node.condition);
+		
+		if(condition.invalid) return ConstantValue.invalid;
+		if(condition.indeterminate) return ConstantValue.indeterminate;
+		
+		return condition.value != BigInteger.ZERO
+			? evaluate(ctx, node.thenExpression)
+			: evaluate(ctx, node.elseExpression);
+	}
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslElaborator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslElaborator.xtend
@@ -1,0 +1,419 @@
+package com.minres.coredsl.analysis
+
+import com.minres.coredsl.coreDsl.AssignmentExpression
+import com.minres.coredsl.coreDsl.BoolTypeSpecifier
+import com.minres.coredsl.coreDsl.CoreDef
+import com.minres.coredsl.coreDsl.CoreDslPackage
+import com.minres.coredsl.coreDsl.Declarator
+import com.minres.coredsl.coreDsl.EntityReference
+import com.minres.coredsl.coreDsl.Expression
+import com.minres.coredsl.coreDsl.ExpressionInitializer
+import com.minres.coredsl.coreDsl.ExpressionStatement
+import com.minres.coredsl.coreDsl.ISA
+import com.minres.coredsl.coreDsl.InstructionSet
+import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
+import com.minres.coredsl.coreDsl.TypeSpecifier
+import com.minres.coredsl.type.CoreDslType
+import com.minres.coredsl.type.ErrorType
+import com.minres.coredsl.validation.IssueCodes
+import java.util.ArrayList
+import java.util.HashSet
+import java.util.List
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.validation.ValidationMessageAcceptor
+
+import static extension com.minres.coredsl.util.ModelExtensions.*
+import static extension com.minres.coredsl.util.ModelUtil.*
+
+class CoreDslElaborator {
+	private new() {}
+	
+	static class ConstantDefinitionInfo {
+		public val String name;
+		public val List<TypeSpecifier> types = new ArrayList;
+		public val List<Declarator> declarators = new ArrayList;
+		public val List<Expression> assignments = new ArrayList;
+		
+		public var CoreDslType calculatedType;
+		public var ConstantValue calculatedValue;
+		public var Integer calculatedBitSize;
+		
+		new(String name) {
+			this.name = name;
+		}
+	}
+	
+	// note: only ever report errors within the lexical scope of the root ISA passed here
+	static def void elaborate(ISA isa, ValidationMessageAcceptor acceptor) {
+		val ctx = new AnalysisContext(isa, acceptor);
+		
+		buildElaborationOrder(ctx, isa);
+		
+		collectConstants(ctx);
+		calculateConstantValues(ctx);
+		mergeConstantDeclarations(ctx);
+		validateConstantDeclarations(ctx);
+		
+	}
+
+	/**
+	 * Populates the context's {@link AnalysisContext#elaborationOrder elaborationOrder} list.
+	 */
+	private static def dispatch void buildElaborationOrder(AnalysisContext ctx, CoreDef core) {
+		for(iset : core.providedInstructionSets) {
+			buildElaborationOrder(ctx, iset);
+		}
+		ctx.elaborationOrder.add(core);
+	}
+
+	/**
+	 * Populates the context's {@link AnalysisContext#elaborationOrder elaborationOrder} list.
+	 */
+	private static def dispatch void buildElaborationOrder(AnalysisContext ctx, InstructionSet iset) {
+		
+		// check for cyclic inheritance
+		if(ctx.currentInheritanceStack.contains(iset)) {
+			// only report the error once (when partial elaboration is run for this instruction set)
+			if(iset != ctx.root) return;
+			
+			val stack = ctx.currentInheritanceStack;
+			val chain = stack.subList(stack.indexOf(iset), stack.size) + #[iset];
+			
+			ctx.acceptor.acceptError(
+				'Cyclic instruction set inheritance: ' + chain.map[it.name].join(' -> '),
+				iset, CoreDslPackage.Literals.INSTRUCTION_SET__SUPER_TYPE,
+				-1, IssueCodes.CyclicInstructionSetInheritance);
+			return;
+		}
+		
+		ctx.currentInheritanceStack.push(iset);
+		{
+			if(iset.superType !== null)
+				buildElaborationOrder(ctx, iset.superType);
+			
+			if(!ctx.elaborationOrder.contains(iset))
+				ctx.elaborationOrder.add(iset);
+		}
+		ctx.currentInheritanceStack.pop();
+	}
+
+	private static def void registerDeclarator(AnalysisContext ctx, Declarator declarator) {
+		val name = declarator.name;
+		val typeSpecifier = declarator.typeSpecifier;
+		if(!ctx.constantDefinitions.containsKey(name))
+			ctx.constantDefinitions.put(name, new ConstantDefinitionInfo(name));
+		
+		val constant = ctx.constantDefinitions.get(name);
+		constant.declarators.add(declarator);
+		constant.types.add(typeSpecifier);
+		
+		switch(typeSpecifier) {
+			IntegerTypeSpecifier | BoolTypeSpecifier: {}
+			
+			default: {
+				ctx.acceptor.acceptError(
+					'ISA level declarations may only use integer types',
+					declarator.declaration, CoreDslPackage.Literals.DECLARATION__TYPE,
+					-1, IssueCodes.InvalidIsaConstantType);
+			}
+		}
+		
+		if(declarator.initializer !== null) {
+			val initializer = declarator.initializer;
+			val expression = switch initializer { ExpressionInitializer: initializer.value };
+			if(expression === null) {
+				ctx.acceptor.acceptError(
+					'ISA level declarations may only use expression initializers',
+					declarator, CoreDslPackage.Literals.DECLARATOR__INITIALIZER,
+					-1, IssueCodes.InvalidIsaConstantAssignmentInitializer);
+				return;
+			}
+			
+			constant.assignments.add(expression);
+		}
+	}
+		
+	private static def void registerAssignment(AnalysisContext ctx, ExpressionStatement statement) {
+		val expression = statement.expression;
+		val assignment = switch expression { AssignmentExpression: expression };
+		
+		if(assignment === null) {
+			ctx.acceptor.acceptError(
+				'Only assignment expressions are allowed in ISA level expression statements',
+				statement, CoreDslPackage.Literals.EXPRESSION_STATEMENT__EXPRESSION,
+				-1, IssueCodes.InvalidIsaConstantAssignmentExpression);
+			return;
+		}
+		
+		if(assignment.operator != '=') {
+			ctx.acceptor.acceptError(
+				'Only regular assignments are allowed on ISA level constants',
+				assignment, CoreDslPackage.Literals.ASSIGNMENT_EXPRESSION__OPERATOR,
+				-1, IssueCodes.InvalidIsaConstantAssignmentOperator);
+			return;
+		}
+		
+		// If someone knows an easier way to perform all of these type checks
+		// without repeating the if below, let me know. I just wish the `as`
+		// operator worked like it does in C#.
+		val assignmentTarget = assignment.target;
+		val entityReference = switch assignmentTarget { EntityReference: assignmentTarget };
+		val referenceTarget = entityReference?.target;
+		val declarator =  switch referenceTarget { Declarator: referenceTarget };
+		val name = declarator?.name;
+		val info = ctx.constantDefinitions.get(name);
+		
+		if(declarator === null || info === null || !info.declarators.contains(declarator)) {
+			// invalid assignment target
+			ctx.acceptor.acceptError(
+				'ISA level assignment must assign to an ISA constant',
+				assignment, CoreDslPackage.Literals.ASSIGNMENT_EXPRESSION__TARGET,
+				-1, IssueCodes.InvalidIsaConstantAssignmentTarget);
+			return;
+		}
+		
+		info.assignments.add(assignment.value);
+	}
+
+	/**
+	 * Registers all declarators and assignments within the {@code architectural_state} sections from the elaboration order.
+	 */
+	private static def void collectConstants(AnalysisContext ctx) {
+		for(isa : ctx.elaborationOrder) {
+			for(declarator : isa.declaredConstants) {
+				ctx.registerDeclarator(declarator);
+			}
+			for(statement : isa.assignments) {
+				ctx.registerAssignment(statement);
+			}
+		}
+	}
+	
+	private static def boolean consolidateValues(AnalysisContext ctx, ConstantDefinitionInfo constant, ConstantValue value) {
+		if(constant.calculatedValue == value) return true;
+		if(constant.calculatedValue === null) {
+			constant.calculatedValue = value;
+			return true;
+		}
+
+		val errorNodes = constant.assignments
+			.map[it.eContainer]
+			.filter[it.parentOfType(ISA) == ctx.root];
+
+		for(node : errorNodes) {
+			switch(node) {
+				Declarator: {
+					ctx.acceptor.acceptError(
+						'Multiple mismatching ISA constant definitions',
+						node, CoreDslPackage.Literals.DECLARATOR__TEQUALS,
+						-1, IssueCodes.MismatchingIsaConstantValues);
+				}
+				AssignmentExpression: {
+					ctx.acceptor.acceptError(
+						'Multiple mismatching ISA constant definitions',
+						node, CoreDslPackage.Literals.ASSIGNMENT_EXPRESSION__OPERATOR,
+						-1, IssueCodes.MismatchingIsaConstantValues);
+				}
+			}
+		}
+		
+		return false;
+	}
+	
+	private static def boolean consolidateTypes(AnalysisContext ctx, ConstantDefinitionInfo constant, CoreDslType type) {
+		if(constant.calculatedType == type) return true;
+		if(constant.calculatedType === null) {
+			constant.calculatedType = type;
+			return true;
+		}
+
+		val errorDeclarators = constant.declarators
+			.filter[it.parentOfType(ISA) == ctx.root];
+
+		for(declarator : errorDeclarators) {
+			ctx.acceptor.acceptError(
+				'ISA constant ' + declarator.name + ' was declared multiple times with different types',
+				declarator, CoreDslPackage.Literals.NAMED_ENTITY__NAME,
+				-1, IssueCodes.MismatchingIsaConstantTypes);
+		}
+		
+		return false;
+	}
+	
+	private static class CalculationJob {
+		public val EObject node;
+		public val ConstantDefinitionInfo constant;
+		
+		new(EObject node, ConstantDefinitionInfo constant) {
+			this.node = node;
+			this.constant = constant;
+		}
+	}
+	
+	/*
+	 * Basic idea: Type sizes and constant values can depend on each other,
+	 * so we treat all type sizes as implicit constants. For each constant
+	 * assignment expression and each declarator a "job" is generated. A job
+	 * either determines the size of a type or the value of an expression.
+	 * 
+	 * The implementation starts off knowing none of the values and tries to
+	 * execute every job. A job can either succeed (if all required values
+	 * are already available), or fail -- either because the expression is
+	 * invalid, or because it depends on some other value that has not been
+	 * determined yet.
+	 * 
+	 * The solver iterates until either all jobs have been completed, or an
+	 * iteration did not generate any new results. In the latter case, the
+	 * appropriate errors are generated.
+	 */
+	private static def void calculateConstantValues(AnalysisContext ctx) {
+		val errorJobs = new HashSet<CalculationJob>;
+		val finishedJobs = new HashSet<CalculationJob>;
+		val remainingJobs = ctx.constantDefinitions
+			.values()
+			.flatMap[constant|
+				(constant.assignments + constant.types)
+				.map[new CalculationJob(it, constant)]]
+			.toSet();
+		
+		var continue = true;
+		
+		while(continue && !remainingJobs.empty) {
+			for(job : remainingJobs) {
+				val node = job.node;
+				switch(node) {
+					Expression: {
+						val value = CoreDslConstantExpressionEvaluator.evaluate(ctx, node);
+						
+						if(value.isValid) {
+							finishedJobs.add(job);
+							if(consolidateValues(ctx, job.constant, value)) {
+								ctx.acceptor.acceptInfo(
+									'Evaluates to ' + value.value,
+									node.eContainer, node.eContainingFeature,
+									-1, IssueCodes.DebugInfo);
+							}
+						}
+						else if(value.status == ConstantValue.StatusCode.invalid) {
+							finishedJobs.add(job);
+							errorJobs.add(job);
+						}
+					}
+					
+					TypeSpecifier: {
+						val type = CoreDslTypeProvider.getSpecifiedType(ctx, node);
+						
+						if(type.isValid) {
+							finishedJobs.add(job);
+							if(consolidateTypes(ctx, job.constant, type)) {
+								ctx.acceptor.acceptInfo(
+									'Type has size ' + type.bitSize,
+									node.eContainer, node.eContainingFeature,
+									-1, IssueCodes.DebugInfo);
+							}
+						}
+						else if((type as ErrorType).errorCode == ErrorType.ErrorCode.invalid) {
+							finishedJobs.add(job);
+							errorJobs.add(job);
+						}
+					}
+				}
+			}
+			
+			// no more progress -> either done or deadlock
+			if(finishedJobs.empty)
+				continue = false;
+			
+			remainingJobs.removeAll(finishedJobs);
+			finishedJobs.clear();
+		}
+		
+		// do not report errors on instruction sets, as they may be incomplete
+		if(!ctx.isPartialAnalysis) {
+			val constants = ctx.constantDefinitions.values;
+			val constantsWithoutAssignments = constants.filter[it.assignments.empty];
+			
+			for(constant : constantsWithoutAssignments) {
+				val errorDeclarators = constant.declarators.filter[it.parentOfType(ISA) == ctx.root];
+				
+				for(declarator : errorDeclarators) {
+					ctx.acceptor.acceptError(
+						'Constant is never assigned',
+						declarator, CoreDslPackage.Literals.NAMED_ENTITY__NAME,
+						-1, IssueCodes.IndeterminableIsaConstantValue);
+				}
+			}
+			
+			val failedValueJobs = remainingJobs.filter[it.node instanceof Expression].toList();
+			for(job : failedValueJobs.filter[it.node.parentOfType(ISA) == ctx.root]) {
+				switch(job.node.eContainer) {
+					ExpressionInitializer: {
+						ctx.acceptor.acceptError(
+							errorJobs.contains(job)
+							? 'Constant value can not be determined'
+							: 'Constant value can not be determined because it depends on another indeterminable constant',
+							job.node.eContainer.eContainer, CoreDslPackage.Literals.NAMED_ENTITY__NAME,
+							-1, IssueCodes.IndeterminableIsaConstantValue);
+					}
+					AssignmentExpression: {
+						ctx.acceptor.acceptError(
+							errorJobs.contains(job)
+							? 'Constant value can not be determined'
+							: 'Constant value can not be determined because it depends on another indeterminable constant',
+							job.node.eContainer, CoreDslPackage.Literals.ASSIGNMENT_EXPRESSION__VALUE,
+							-1, IssueCodes.IndeterminableIsaConstantValue);
+					}
+				}
+			}
+			
+			val failedTypeJobs = remainingJobs.filter[it.node instanceof TypeSpecifier].toList();
+			for(job : failedTypeJobs) {
+				val declarator = job.constant.declarators.findFirst[it.typeSpecifier == job.node];
+				ctx.acceptor.acceptError(
+					errorJobs.contains(job)
+					? 'Constant type can not be determined'
+					: 'Constant type can not be determined because it depends on another indeterminable constant',
+					declarator, CoreDslPackage.Literals.NAMED_ENTITY__NAME,
+					-1, IssueCodes.IndeterminableIsaConstantValue);
+			}
+			
+			val failedValueConstants = constants.filter[it.calculatedValue === null].map[it.name].toList();
+			if(!failedValueConstants.empty) {
+				ctx.acceptor.acceptError(
+					'Some constants could not be calculated: ' + failedValueConstants.join(', '),
+					ctx.root, CoreDslPackage.Literals.ISA__NAME,
+					-1, IssueCodes.IndeterminableIsaConstantValue);
+			}
+			
+			val failedTypeConstants = constants.filter[it.calculatedType === null].map[it.name].toList();
+			if(!failedTypeConstants.empty) {
+				ctx.acceptor.acceptError(
+					'The type of some constants could not be calculated: ' + failedTypeConstants.join(', '),
+					ctx.root, CoreDslPackage.Literals.ISA__NAME,
+					-1, IssueCodes.IndeterminableIsaConstantValue);
+			}
+		}
+		
+		// TODO
+		// evaluate the right hand sides of all assignments
+		// -> report cyclic dependencies: x=y; y=x;
+		// -> how do we handle breakable cycles? x=y; y=x; x=1;
+		//   -> fixpoint solver?
+		// make sure all assignments to the same constant result in the same value
+		// store the calculated values in the ConstantDefinitionInfo object
+	}
+	
+	private static def void mergeConstantDeclarations(AnalysisContext ctx) {
+		// TODO
+		// evaluate integer type widths
+		// make sure all types of each constant are equal
+		// make sure no two declarations are in the same ISA scope
+	}
+	
+	private static def void validateConstantDeclarations(AnalysisContext ctx) {
+		// TODO
+		// make sure only primitive types (and enums?) are used
+		// make sure all calculated values can fit into their respective constant's type
+	}
+	
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslTypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslTypeProvider.xtend
@@ -1,0 +1,72 @@
+package com.minres.coredsl.analysis
+
+import com.minres.coredsl.coreDsl.BoolTypeSpecifier
+import com.minres.coredsl.coreDsl.CoreDslPackage
+import com.minres.coredsl.coreDsl.IntegerSignedness
+import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
+import com.minres.coredsl.coreDsl.TypeSpecifier
+import com.minres.coredsl.type.ErrorType
+import com.minres.coredsl.type.IntegerType
+import com.minres.coredsl.validation.IssueCodes
+
+class CoreDslTypeProvider {
+	private new() {}
+	
+	static def dispatch getSpecifiedType(AnalysisContext ctx, IntegerTypeSpecifier specifier) {
+		if(specifier.size !== null) {
+			val size = CoreDslConstantExpressionEvaluator.evaluate(ctx, specifier.size);
+			
+			if(size.invalid) return ErrorType.invalid;
+			if(size.indeterminate) return ErrorType.indeterminate;
+			
+			try {
+				val isSigned = specifier.signedness === IntegerSignedness.SIGNED;
+				val exactSize = size.value.intValueExact();
+				
+				if(exactSize < 0) {
+					ctx.acceptor.acceptError(
+						'Integer type size must not be negative',
+						specifier, CoreDslPackage.Literals.INTEGER_TYPE_SPECIFIER__SIZE,
+						-1, IssueCodes.InvalidIntegerTypeSize);
+					return ErrorType.invalid;
+				}
+				
+				if(exactSize == 0 && isSigned) {
+					ctx.acceptor.acceptError(
+						'signed<0> is not a valid type',
+						specifier, CoreDslPackage.Literals.INTEGER_TYPE_SPECIFIER__SIZE,
+						-1, IssueCodes.InvalidIntegerTypeSize);
+					return ErrorType.invalid;
+				}
+				
+				return new IntegerType(exactSize, isSigned);
+			}
+			catch(ArithmeticException e) {
+				ctx.acceptor.acceptError(
+					'Integer type size must not exceed Integer.MAX_VALUE',
+					specifier, CoreDslPackage.Literals.INTEGER_TYPE_SPECIFIER__SIZE,
+					-1, IssueCodes.InvalidIntegerTypeSize);
+				return ErrorType.invalid;
+			}
+		}
+		
+		val isSigned = specifier.signedness !== IntegerSignedness.UNSIGNED;
+		val size = switch(specifier.shorthand) {
+			case CHAR: 8
+			case SHORT: 16
+			case INT: 32
+			case LONG: 64
+		};
+		
+		return new IntegerType(size, isSigned);
+	}
+	
+	static def dispatch getSpecifiedType(AnalysisContext ctx, BoolTypeSpecifier specifier) {
+		return IntegerType.bool;
+	}
+	
+	static def dispatch getSpecifiedType(AnalysisContext ctx, TypeSpecifier specifier) {
+		// TODO implement the rest
+		return ErrorType.invalid;
+	}
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/type/CoreDslType.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/type/CoreDslType.xtend
@@ -1,0 +1,20 @@
+package com.minres.coredsl.type
+
+import org.eclipse.xtend.lib.annotations.Data
+
+@Data
+abstract class CoreDslType {
+	int bitSize;
+	
+	def isPrimitiveType() { return false; }
+	def isIntegerType() { return false; }
+	def isFloatType() { return false; }
+	def isStructType() { return false; }
+	def isUnionType() { return false; }
+	def isEnumType() { return false; }
+	
+	def isValid() { return bitSize >= 0; }
+	def isError() { return bitSize < 0; }
+	def isInvalid() { return this == ErrorType.invalid; }
+	def isIndeterminate() { return this == ErrorType.indeterminate; }
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/type/ErrorType.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/type/ErrorType.xtend
@@ -1,0 +1,21 @@
+package com.minres.coredsl.type
+
+import org.eclipse.xtend.lib.annotations.Data
+
+@Data
+class ErrorType extends CoreDslType {
+	public static ErrorType indeterminate = new ErrorType(ErrorCode.indeterminate);
+	public static ErrorType invalid = new ErrorType(ErrorCode.invalid);
+
+	ErrorCode errorCode;
+
+	private new(ErrorCode errorCode) {
+		super(-1);
+		this.errorCode = errorCode;
+	}
+
+	enum ErrorCode {
+		indeterminate,
+		invalid
+	}
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/type/IntegerType.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/type/IntegerType.xtend
@@ -1,0 +1,18 @@
+package com.minres.coredsl.type
+
+import org.eclipse.xtend.lib.annotations.Data
+
+@Data
+class IntegerType extends CoreDslType {
+	public static val IntegerType bool = new IntegerType(1, false);
+
+	boolean isSigned;
+
+	new(int bitSize, boolean isSigned) {
+		super(bitSize);
+		this.isSigned = isSigned;
+	}
+
+	override isPrimitiveType() { return true; }
+	override isIntegerType() { return true; }
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/util/CompilerAssertionError.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/util/CompilerAssertionError.xtend
@@ -1,0 +1,7 @@
+package com.minres.coredsl.util
+
+import java.lang.RuntimeException
+
+class CompilerAssertionError extends RuntimeException {
+	new(String message) { super(message); }
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/util/ModelExtensions.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/util/ModelExtensions.xtend
@@ -1,0 +1,51 @@
+package com.minres.coredsl.util
+
+import com.minres.coredsl.coreDsl.Declaration
+import com.minres.coredsl.coreDsl.Declarator
+import com.minres.coredsl.coreDsl.ISA
+import com.minres.coredsl.coreDsl.TypeSpecifier
+
+class ModelExtensions {
+	private new() {}
+	
+	static def void assertThat(boolean condition, String errorMsg) {
+		if(!condition) throw new CompilerAssertionError(errorMsg);
+	}
+	
+	// Declarator extensions
+	
+	/**
+	 * Returns the declaration the declarator belongs to.
+	 */
+	static def Declaration getDeclaration(Declarator declarator) {
+		assertThat(declarator.eContainer instanceof Declaration,
+			'Parent node of a declarator must always be a declaration');
+		
+		return declarator.eContainer as Declaration;
+	}
+	
+	/**
+	 * Returns the type specifier of the declaration the declarator belongs to.
+	 */
+	static def TypeSpecifier getTypeSpecifier(Declarator declarator) {
+		return declarator.declaration.type;
+	}
+	
+	/**
+	 * Returns true of the declarator belongs to a declaration in the
+	 * {@code architectural_state} section of an instruction set or core definition.
+	 */
+	static def boolean isIsaConstant(Declarator declarator) {
+		return declarator.declaration.eContainer instanceof ISA;
+	}
+	
+	// ISA extensions
+	
+	/**
+	 * Returns all declarators declared in the {@code architectural_state} section
+	 * of this ISA, <b>excluding</b> those declared in any parent types.
+	 */
+	static def Iterable<Declarator> getDeclaredConstants(ISA isa) {
+		return isa.declarations.flatMap[it.declaration.declarators];
+	}
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/util/SyntaxTreeWalker.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/util/SyntaxTreeWalker.xtend
@@ -1,0 +1,61 @@
+package com.minres.coredsl.util
+
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.common.util.EList
+import java.util.ArrayList
+
+class SyntaxTreeWalker {
+
+	static def Iterable<EObject> getChildren(EObject node) {
+		return node.eClass.EStructuralFeatures
+			.map[node.eGet(it)]
+			.flatMap [switch (it) {
+				EList<EObject>: return it
+				EObject: return #[it]
+				default: return #[]
+			}
+		];
+	}
+	
+	// descendants
+
+	private static def Iterable<EObject> getDescendants(EObject node, boolean preOrder, boolean postOrder) {
+		val list = new ArrayList<EObject>;
+		iterate(node, [list.add(it)], preOrder, postOrder);
+		return list;
+	}
+
+	static def Iterable<EObject> getDescendantsPreOrder(EObject node) {
+		return getDescendants(node, true, false);
+	}
+
+	static def Iterable<EObject> getDescendantsPostOrder(EObject node) {
+		return getDescendants(node, false, true);
+	}
+
+	static def <T extends EObject> Iterable<T> getDescendantsPreOrder(EObject node, Class<T> filterType) {
+		return node.descendantsPreOrder.filter(filterType);
+	}
+
+	static def <T extends EObject> Iterable<T> getDescendantsPostOrder(EObject node, Class<T> filterType) {
+		return node.descendantsPostOrder.filter(filterType);
+	}
+	
+	// enumeration
+
+	private static def void iterate(EObject node, (EObject)=>void action, boolean preOrder, boolean postOrder) {
+		if(preOrder) action.apply(node);
+		for (child : node.children) {
+			iterate(child, action, preOrder, postOrder);
+		}
+		if(postOrder) action.apply(node);
+	}
+
+	static def void iteratePreOrder(EObject node, (EObject)=>void action) {
+		iterate(node, action, true, false);
+	}
+
+	static def void iteratePostOrder(EObject node, (EObject)=>void action) {
+		iterate(node, action, true, false);
+	}
+}

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
@@ -3,5 +3,27 @@ package com.minres.coredsl.validation
 class IssueCodes {
 	private new() {}
 	
-	public static final String SyntaxError = "org.eclipse.xtext.diagnostics.Diagnostic.Syntax";
+	public static val SyntaxError = 'org.eclipse.xtext.diagnostics.Diagnostic.Syntax';
+	
+	public static val _prefix = "com.minres.coredsl."
+	
+	// utility issues
+	public static val DebugInfo = _prefix + 'DebugInfo';
+	
+	// type issues
+	public static val InvalidIntegerTypeSize = _prefix + 'InvalidIntegerTypeSize';
+	
+	// elaboration issues
+	public static val CyclicInstructionSetInheritance = _prefix + 'CyclicInstructionSetInheritance';
+	public static val InvalidIsaConstantAssignmentInitializer = _prefix + 'InvalidIsaConstantAssignmentInitializer';
+	public static val InvalidIsaConstantAssignmentExpression = _prefix + 'InvalidIsaConstantAssignmentExpression';
+	public static val InvalidIsaConstantAssignmentOperator = _prefix + 'InvalidIsaConstantAssignmentOperator';
+	public static val InvalidIsaConstantAssignmentTarget = _prefix + 'InvalidIsaConstantAssignmentTarget';
+	public static val InvalidIsaConstantType = _prefix + 'InvalidIsaConstantType';
+	public static val IndeterminableIsaConstantValue = _prefix + 'IndeterminableIsaConstantValue';
+	public static val IndeterminableIsaConstantType = _prefix + 'IndeterminableIsaConstantType';
+	public static val MismatchingIsaConstantValues = _prefix + 'MismatchingIsaConstantValues';
+	public static val MismatchingIsaConstantTypes = _prefix + 'MismatchingIsaConstantTypes';
+	
+	public static val InvalidConstantExpressionNode = _prefix + 'InvalidConstantExpressionNode';
 }

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/XtCoreDslValidator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/XtCoreDslValidator.xtend
@@ -22,6 +22,7 @@ import com.minres.coredsl.coreDsl.FunctionDefinition
 import com.minres.coredsl.validation.KnownAttributes.AttributeUsage
 import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.ecore.EStructuralFeature
+import com.minres.coredsl.analysis.CoreDslElaborator
 
 /**
  * This class contains custom validation rules. 
@@ -42,6 +43,11 @@ class XtCoreDslValidator extends CoreDslValidator {
 	public static val TYPE_ILLEGAL = ISSUE_CODE_PREFIX + "TypeIllegal"
 	public static val ILLEGAL_ATTRIBUTE = ISSUE_CODE_PREFIX + "IllegalAttribute"
 	public static val INVALID_ATTRIBUTE_PARAMETERS = ISSUE_CODE_PREFIX + "InvalidAttributeParameters"
+
+	@Check
+	def testElaborate(ISA isa) {
+		CoreDslElaborator.elaborate(isa, this);
+	}
 
 	// @Check
 	def checkType(Expression e) {


### PR DESCRIPTION
This PR marks the start of a new analysis implementation. It lives in `com.minres.coredsl.analysis` and my plan is to eventually replace all of the existing analysis facilities, including the `TypeProvider` and `CoreDslInterpreter`.

Even though it is still a draft, the elaboration is mostly functional and can be tested by running the IDE project.

# Architecture
All of the analyzers are static classes, meaning they cannot be instantiated and provide their functionality through static methods. Because of this they cannot store any state, which is why they are passed an `AnalysisContext` for every operation.

## Analysis Context
**Full path:** `com.minres.coredsl.analysis.AnalysisContext`
**Replaces:** `com.minres.coredsl.interpreter.EvaluationContext`

**Reponsibilities:**
- Holding state of analysis operations
- Providing an interface through which errors and warnings can be reported
  - *Note: errors should only ever be reported on nodes within the lexical scope of the analysis root*

## Type Classes
**Full path:** `com.minres.coredsl.type.*`
**Replaces:** `com.minres.coredsl.typing.DataType`

**Reponsibilities:**
- Representing types of variables within CoreDSL descriptions
- Special `ErrorType` to signal errors during type resolution
  - `ErrorType.invalid` - an unrecoverable error occured during type analysis (for example violated type rules)
  - `ErrorType.indeterminate` - the type can not be determined because it depends on unassigned constants
- Separate classes for type caregories - currently only `IntegerType` and `ErrorType` exist
- `is{*}Type` helpers

## Constant Value Class
**Full path:** `com.minres.coredsl.analysis.ConstantValue`
**Replaces:** `com.minres.coredsl.interpreter.Value`

**Reponsibilities:**
- Representing the value of a constant expression
- Special constants
  - `ConstantValue.invalid` - the expression is not a constant or can not be evaluated
  - `ConstantValue.indeterminate` - the expression can not be evaluated because it depends on another unresolved value

## Type Provider
**Full path:** `com.minres.coredsl.analysis.CoreDslTypeProvider`
**Replaces:** `com.minres.coredsl.typing.TypeProvider`

**Reponsibilities:**
- Determining the type specified by `TypeSpecifier` nodes (`getSpecifiedType`)
- Determining the static type of `Expression` nodes (not implemented)

**Important methods:**
- `CoreDslType getSpecifiedType(AnalysisContext ctx, TypeSpecifier specifier)`
- `CoreDslType getStaticType(AnalysisContext ctx, Expression expression)`

**Related classes:**
- `AnalysisContext` - to look up the type of identifiers
- `CoreDslConstantExpressionEvaluator` - to determine the value of integer size specifiers

## Constant Expression Evaluator
**Full path:** `com.minres.coredsl.analysis.CoreDslConstantExpressionEvaluator`
**Replaces:** `com.minres.coredsl.interpreter.CoreDslInterpreter`

**Reponsibilities:**
- Determining the value of compile-time constant expressions

**Important methods:**
- `ConstantValue evaluate(AnalysisContext ctx, Expression expression)`

**Related classes:**
- `AnalysisContext` - to look up the value of ISA constants
- `CoreDslTypeProvider` - to resolve the types used within `sizeof` and `bitsizeof` expressions

## Elaborator
**Full path:** `com.minres.coredsl.analysis.CoreDslElaborator`
**Replaces:** nothing

**Reponsibilities:**
- Resolving the values and types of ISA constants
- Merging constant declarations across instruction sets

**Important methods:**
- `void elaborate(ISA isa, ValidationMessageAcceptor acceptor)`

**Related classes:**
- `AnalysisContext` - holds state
- `CoreDslConstantExpressionEvaluator` - to determine the value of ISA constants
- `CoreDslTypeProvider` - to determine the type of ISA constants

## Analyzer
**Full path:** `com.minres.coredsl.analysis.CoreDslAnalyzer`
**Replaces:** nothing

**Reponsibilities:**
- Tying together all of the other analyzers (not implemented)
- Providing an interface to the outside (not implemented)