### PR TITLE
Support list initializers for 1D integer arrays.

### DIFF
--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
@@ -641,6 +641,9 @@ class CoreDslAnalyzer {
 							ctx.acceptError("Cannot implicitly convert " + valueType + " to " + arrayType.elementType, declarator,
 							CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.InvalidAssignmentType);
 						}
+						if(isIsaStateElement) {
+							CoreDslConstantExpressionEvaluator.evaluate(ctx, subInitializer.value);
+						}
 					} else {
 						ctx.acceptError("Nested listed initializers are currently unsupported", declarator,
 							CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.UnsupportedLanguageFeature);

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
@@ -625,6 +625,25 @@ class CoreDslAnalyzer {
 					ctx.acceptError("Cannot implicitly convert " + valueType + " to " + type, declarator,
 						CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.InvalidAssignmentType);
 				}
+			} else if(type.isArrayType) {
+				val listInitializer = initializer as ListInitializer;
+				val arrayType = type as ArrayType;
+				if (arrayType.count != listInitializer.initializers.size)
+					ctx.acceptError("List initializer size does not match array size", declarator,
+						CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.InvalidAssignmentType);
+				for (subInitializer : listInitializer.initializers) {
+					if(subInitializer instanceof ExpressionInitializer) {
+						val expressionInitializer = subInitializer as ExpressionInitializer;
+						val valueType = analyzeExpression(ctx, expressionInitializer.value);
+						if(!CoreDslTypeProvider.canImplicitlyConvert(valueType, arrayType.elementType)) {
+							ctx.acceptError("Cannot implicitly convert " + valueType + " to " + arrayType.elementType, declarator,
+							CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.InvalidAssignmentType);
+						}
+					} else {
+						ctx.acceptError("Nested listed initializers are currently unsupported", declarator,
+							CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.UnsupportedLanguageFeature);
+					}
+				}
 			} else if(type.isStructType) {
 				// TODO list initializers
 				ctx.acceptError("List initializers are currently unsupported ", declarator,

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
@@ -559,7 +559,9 @@ class CoreDslAnalyzer {
 	/**
 	 * 1. Const declarators must be initialized. <i>(UninitializedConstant)</i><br>
 	 * 2. Alias declarators must fulfill additional requirements.<br>
-	 * 3. If the declarator uses an expression initializer, the expression's type must be implicitly convertible to the declarator's type. <i>(InvalidAssignmentType)</i><br>
+	 * 3a. If the declarator uses an expression initializer, the expression's type must be implicitly convertible to the declarator's type. <i>(InvalidAssignmentType)</i><br>
+	 * 3b. If an array declarator uses an list initializer, the number of elements in the array type must match the number of elements in the initializer,
+	 *     and all elements must be implicitly convertible to array's element type. <i>(InvalidAssignmentType)</i><br>
 	 * 4. ISA parameters must not be declared as arrays. <i>(InvalidIsaParameterDeclaration)</i><br>
 	 * 5. Array dimension specifiers must be non-negative constant values. <i>(InvalidArraySize)</i><br>
 	 * 6. [Warning] Array dimension specifiers should not be zero. <i>(InvalidArraySize)</i>

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
@@ -560,7 +560,7 @@ class CoreDslAnalyzer {
 	 * 1. Const declarators must be initialized. <i>(UninitializedConstant)</i><br>
 	 * 2. Alias declarators must fulfill additional requirements.<br>
 	 * 3a. If the declarator uses an expression initializer, the expression's type must be implicitly convertible to the declarator's type. <i>(InvalidAssignmentType)</i><br>
-	 * 3b. If an array declarator uses an list initializer, the number of elements in the array type must match the number of elements in the initializer,
+	 * 3b. If an array declarator uses a list initializer, the number of elements in the array type must match the number of elements in the initializer,
 	 *     and all elements must be implicitly convertible to array's element type. <i>(InvalidAssignmentType)</i><br>
 	 * 4. ISA parameters must not be declared as arrays. <i>(InvalidIsaParameterDeclaration)</i><br>
 	 * 5. Array dimension specifiers must be non-negative constant values. <i>(InvalidArraySize)</i><br>
@@ -635,8 +635,7 @@ class CoreDslAnalyzer {
 						CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.InvalidAssignmentType);
 				for (subInitializer : listInitializer.initializers) {
 					if(subInitializer instanceof ExpressionInitializer) {
-						val expressionInitializer = subInitializer as ExpressionInitializer;
-						val valueType = analyzeExpression(ctx, expressionInitializer.value);
+						val valueType = analyzeExpression(ctx, subInitializer.value);
 						if(!CoreDslTypeProvider.canImplicitlyConvert(valueType, arrayType.elementType)) {
 							ctx.acceptError("Cannot implicitly convert " + valueType + " to " + arrayType.elementType, declarator,
 							CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.InvalidAssignmentType);
@@ -645,7 +644,7 @@ class CoreDslAnalyzer {
 							CoreDslConstantExpressionEvaluator.evaluate(ctx, subInitializer.value);
 						}
 					} else {
-						ctx.acceptError("Nested listed initializers are currently unsupported", declarator,
+						ctx.acceptError("Nested list initializers are unsupported", declarator,
 							CoreDslPackage.Literals.DECLARATOR__TEQUALS, -1, IssueCodes.UnsupportedLanguageFeature);
 					}
 				}


### PR DESCRIPTION
This is not a generic solution I yet; I mainly need this (and tested it for) writing constant registers like:

```
architectural_state {
  const register unsigned<8> ROT_0[4] = {31, 17, 0, 24};
  const register unsigned<8> ROT_1[4] = {24, 17, 31, 16};
  const register unsigned<32> RCON[8] =
      {0xB7E15162, 0xBF715880, 0x38B4DA56, 0x324E7738,
      0xBB1185EB, 0x4F7C7B57, 0xCFBFA1C8, 0xC2B3293D};
}
```