### PR TITLE
Scoping Fixes

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTestCase.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/CoreDslTestCase.xtend
@@ -212,12 +212,7 @@ class CoreDslTestCase<TRoot> {
 
 		printHeader();
 
-		val diagnosticsErrors = model.eResource.errors.map[convertDiagnostic(it, Severity.ERROR)];
-		val diagnosticsWarnings = model.eResource.warnings.map[convertDiagnostic(it, Severity.WARNING)];
-
 		var issues = new ArrayList();
-		issues.addAll(diagnosticsErrors);
-		issues.addAll(diagnosticsWarnings);
 
 		var AnalysisResults results = null;
 
@@ -226,6 +221,11 @@ class CoreDslTestCase<TRoot> {
 			results = CoreDslAnalyzer.analyze(model, sink);
 			issues.addAll(sink.issues);
 		}
+
+		val diagnosticsErrors = model.eResource.errors.map[convertDiagnostic(it, Severity.ERROR)];
+		val diagnosticsWarnings = model.eResource.warnings.map[convertDiagnostic(it, Severity.WARNING)];
+		issues.addAll(diagnosticsErrors);
+		issues.addAll(diagnosticsWarnings);
 
 		val actualIssues = issues.sortBy[it.severity].sortBy[it.code].sortBy[it.lineNumber];
 		val expectedIssues = expectedIssues.sortBy[it.severity].sortBy[it.code].sortBy[it.lineNumber];

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/analysis/CoreDslScopingTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/analysis/CoreDslScopingTest.xtend
@@ -1,0 +1,64 @@
+package com.minres.coredsl.tests.analysis
+
+import com.google.inject.Inject
+import com.minres.coredsl.tests.CoreDslInjectorProvider
+import com.minres.coredsl.tests.CoreDslTestHelper
+import com.minres.coredsl.validation.IssueCodes
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.extensions.InjectionExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.^extension.ExtendWith
+
+@ExtendWith(InjectionExtension)
+@InjectWith(CoreDslInjectorProvider)
+class CoreDslScopingTest {
+	
+	@Inject extension CoreDslTestHelper testHelper;
+	
+	@Test
+	def void isaLevel() {
+		// use before declaration: initializer
+		'''
+			Core C {
+				architectural_state {
+					unsigned int Y = Y;
+				}
+			}
+		'''
+		.testProgram()
+		.expectError(IssueCodes.InvalidIsaStateElementValue, 1)
+		// the linking error is what we are really checking for, the one above may change
+		.expectError(IssueCodes.LinkingError, 3)
+		.run();
+		
+		// use before declaration: multiple initializers
+		'''
+			Core C {
+				architectural_state {
+					unsigned int Y = X, X = 5;
+				}
+			}
+		'''
+		.testProgram()
+		.expectError(IssueCodes.InvalidIsaStateElementValue, 1)
+		// the linking error is what we are really checking for, the one above may change
+		.expectError(IssueCodes.LinkingError, 3)
+		.run();
+		
+		// use before declaration: use in type
+		'''
+			Core C {
+				architectural_state {
+					unsigned<X> X = 32;
+					unsigned<bitsizeof(Y)> Y = 32;
+				}
+			}
+		'''
+		.testProgram()
+		.expectError(IssueCodes.InvalidIsaStateElementType, 1)
+		// the linking errors are what we are really checking for, the one above may change
+		.expectError(IssueCodes.LinkingError, 3)
+		.expectError(IssueCodes.LinkingError, 4)
+		.run();
+	}
+}

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/analysis/CoreDslScopingTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/analysis/CoreDslScopingTest.xtend
@@ -61,4 +61,95 @@ class CoreDslScopingTest {
 		.expectError(IssueCodes.LinkingError, 4)
 		.run();
 	}
+	
+	@Test
+	def void enums() {
+		// access to enum members
+		'''
+			Core C {
+				architectural_state {
+					unsigned int X = 0;
+					unsigned int Y = x;
+					
+					enum E {
+						x = X
+					}
+				}
+			}
+		'''
+		.testProgram()
+		.run();
+		
+		'''
+			Core C {
+				architectural_state {
+					unsigned int X = 0;
+					
+					enum E {
+						x = X
+					}
+				}
+			}
+		'''
+		.testProgram()
+		.run();
+	}
+	
+	@Test
+	def void compoundStatement() {
+		// use before declaration: initializer
+		'''
+			unsigned int y = y;
+		'''
+		.testStatements()
+		.expectError(IssueCodes.LinkingError, 1)
+		.run();
+		
+		// use before declaration: multiple initializers
+		'''
+			unsigned int y = x, x = 5;
+		'''
+		.testStatements()
+		.expectError(IssueCodes.LinkingError, 1)
+		.run();
+		
+		// use before declaration: use in type
+		'''
+			unsigned<X> X = 32;
+			unsigned<bitsizeof(Y)> Y = 32;
+		'''
+		.testStatements()
+		.expectError(IssueCodes.LinkingError, 1)
+		.expectError(IssueCodes.LinkingError, 2)
+		.run();
+	}
+	
+	@Test
+	def void forLoop() {
+		// invalid access
+		'''
+			for(int x = x;;) {
+				x = x;
+			}
+		'''
+		.testStatements()
+		.expectError(IssueCodes.LinkingError, 1)
+		.run();
+		
+		// valid access
+		'''
+			int y = 0;
+			for(int x = y; x < 10; x++) x = x;
+		'''
+		.testStatements()
+		.run();
+		
+		// access to outer scope
+		'''
+			int x;
+			for(x = 0; x < 10; x++) x = x;
+		'''
+		.testStatements()
+		.run();
+	}
 }

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
@@ -1586,12 +1586,17 @@ class CoreDslAnalyzer {
 	}
 
 	def static dispatch CoreDslType analyzeExpression(AnalysisContext ctx, MemberAccessExpression expression) {
-		val member = expression.declarator;
+		var baseType = analyzeExpression(ctx, expression.target);
 
-		if(member === null || member.eIsProxy)
+		if(!baseType.isCompositeType) {
+			if(baseType.isValid) {
+				ctx.acceptError('Cannot access fields of non-struct type ' + baseType, expression,
+					CoreDslPackage.Literals.MEMBER_ACCESS_EXPRESSION__TARGET, -1, IssueCodes.InvalidMemberAccessTarget);
+			}
 			return ctx.setExpressionType(expression, ErrorType.invalid);
+		}
 
-		return ctx.setExpressionType(expression, ctx.getDeclaredType(member));
+		return ctx.setExpressionType(expression, ctx.getDeclaredType(expression.declarator));
 	}
 
 	def static dispatch CoreDslType analyzeExpression(AnalysisContext ctx, ParenthesisExpression expression) {

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
@@ -1085,7 +1085,7 @@ class CoreDslAnalyzer {
 				}
 			}
 			default: {
-				CompilerAssertion.fail("Invalid entity reference");
+				CompilerAssertion.assertThat(expression.target.eIsProxy, "Invalid entity reference");
 			}
 		}
 	}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslAnalyzer.xtend
@@ -1119,7 +1119,7 @@ class CoreDslAnalyzer {
 				ctx.acceptError("Cannot cast from " + valueType + " to " + targetType, expression,
 					CoreDslPackage.Literals.CAST_EXPRESSION__TARGET_TYPE, -1, IssueCodes.InvalidCast);
 			}
-			if(targetType.equals(valueType)) {
+			if(targetType.equals(valueType) && !targetType.isIncomplete) {
 				ctx.acceptWarning("Identity cast does nothing", expression,
 					CoreDslPackage.Literals.CAST_EXPRESSION__TARGET_TYPE, -1, IssueCodes.IdentityCast);
 			}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslConstantExpressionEvaluator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslConstantExpressionEvaluator.xtend
@@ -44,6 +44,11 @@ class CoreDslConstantExpressionEvaluator {
 
 	def private static dispatch ConstantValue evaluateImpl(AnalysisContext ctx, EntityReference expression,
 		boolean suppressErrors) {
+		if(expression.target.eIsProxy) {
+			// linking error should already be reported
+			return ConstantValue.invalid;
+		}
+			
 		val declarator = expression.target.castOrNull(Declarator);
 
 		if(declarator !== null && !ctx.isStorageClassSet(declarator))
@@ -151,7 +156,7 @@ class CoreDslConstantExpressionEvaluator {
 					EntityReference: {
 						val declarator = arg.target.castOrNull(Declarator);
 						if(declarator !== null) {
-							val type = CoreDslTypeProvider.getSpecifiedType(ctx, declarator.type);
+							val type = CoreDslTypeProvider.tryGetSpecifiedType(ctx, declarator.type);
 							return getTypeSize(ctx, type, inBytes, target);
 						}
 					}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslConstantExpressionEvaluator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslConstantExpressionEvaluator.xtend
@@ -108,6 +108,17 @@ class CoreDslConstantExpressionEvaluator {
 				ctx.acceptError("Division by zero", expression, CoreDslPackage.Literals.INFIX_EXPRESSION__OPERATOR, -1,
 					IssueCodes.DivisionByZero);
 			}
+			case '&':
+				return new ConstantValue(left.value.and(right.value))
+			case '|':
+				return new ConstantValue(left.value.or(right.value))
+			case '^':
+				return new ConstantValue(left.value.xor(right.value))
+			// TODO these ignore all type rules for now, because the evaluator does not track types at all
+			case '<<':
+				return new ConstantValue(left.value.shiftLeft(right.value.intValueExact))
+			case '>>':
+				return new ConstantValue(left.value.shiftRight(right.value.intValueExact))
 			default: {
 				if(!suppressErrors) {
 					ctx.acceptError("Infix expression " + expression.operator +

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslConstantExpressionEvaluator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslConstantExpressionEvaluator.xtend
@@ -48,7 +48,7 @@ class CoreDslConstantExpressionEvaluator {
 			// linking error should already be reported
 			return ConstantValue.invalid;
 		}
-			
+
 		val declarator = expression.target.castOrNull(Declarator);
 
 		if(declarator !== null && !ctx.isStorageClassSet(declarator))
@@ -143,10 +143,10 @@ class CoreDslConstantExpressionEvaluator {
 			case 'sizeof': {
 				val inBytes = expression.function == 'sizeof';
 				val target = new IssueReportTarget(expression, CoreDslPackage.Literals.INTRINSIC_EXPRESSION__FUNCTION);
-				
+
 				if(expression.arguments.size !== 1)
 					return ConstantValue.invalid;
-				
+
 				val arg = expression.arguments.get(0);
 				switch (arg) {
 					TypeSpecifier: {
@@ -156,7 +156,7 @@ class CoreDslConstantExpressionEvaluator {
 					EntityReference: {
 						val declarator = arg.target.castOrNull(Declarator);
 						if(declarator !== null) {
-							val type = CoreDslTypeProvider.tryGetSpecifiedType(ctx, declarator.type);
+							val type = CoreDslTypeProvider.tryGetDeclaratorType(ctx, declarator);
 							return getTypeSize(ctx, type, inBytes, target);
 						}
 					}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslElaborator.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslElaborator.xtend
@@ -186,6 +186,10 @@ class CoreDslElaborator {
 			ctx.acceptError('Only regular assignments (=) are allowed in ISA level expression statements', assignment,
 				CoreDslPackage.Literals.ASSIGNMENT_EXPRESSION__OPERATOR, -1,
 				IssueCodes.InvalidIsaParameterAssignmentOperator);
+		}
+		
+		if(reference?.target.eIsProxy) {
+			// linking error
 			return;
 		}
 

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslTypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslTypeProvider.xtend
@@ -2,6 +2,9 @@ package com.minres.coredsl.analysis
 
 import com.minres.coredsl.coreDsl.BoolTypeSpecifier
 import com.minres.coredsl.coreDsl.CoreDslPackage
+import com.minres.coredsl.coreDsl.Declaration
+import com.minres.coredsl.coreDsl.Declarator
+import com.minres.coredsl.coreDsl.EnumTypeDeclaration
 import com.minres.coredsl.coreDsl.EnumTypeSpecifier
 import com.minres.coredsl.coreDsl.IntegerSignedness
 import com.minres.coredsl.coreDsl.IntegerTypeSpecifier
@@ -120,6 +123,20 @@ abstract class CoreDslTypeProvider {
 		}
 	}
 
+	def static CoreDslType tryGetDeclaratorType(AnalysisContext ctx, Declarator declarator) {
+		val parent = declarator.eContainer;
+		switch(parent) {
+			Declaration: {
+				return tryGetSpecifiedType(ctx, parent.type);
+			}
+			EnumTypeDeclaration: {
+				return ctx.isUserTypeInstanceSet(parent) ? ctx.getUserTypeInstance(parent) : ErrorType.indeterminate;
+			}
+		}
+		
+		return ErrorType.invalid;
+	}
+	
 	def static boolean canTypeHoldValue(CoreDslType type, BigInteger value) {
 		return canImplicitlyConvert(getSmallestTypeForValue(value), type);
 	}

--- a/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslTypeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/analysis/CoreDslTypeProvider.xtend
@@ -20,6 +20,13 @@ import java.math.BigInteger
 abstract class CoreDslTypeProvider {
 	private new() {
 	}
+	
+	def static CoreDslType tryGetSpecifiedType(AnalysisContext ctx, TypeSpecifier typeSpecifier) {
+		if(ctx.isSpecifiedTypeSet(typeSpecifier))
+			return ctx.getSpecifiedType(typeSpecifier);
+			
+		return ErrorType.indeterminate;
+	}
 
 	def static CoreDslType getSpecifiedType(AnalysisContext ctx, TypeSpecifier typeSpecifier) {
 		if(ctx.isSpecifiedTypeSet(typeSpecifier))

--- a/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
@@ -36,6 +36,7 @@ import org.eclipse.xtext.scoping.Scopes
 
 import static extension com.minres.coredsl.util.DataExtensions.*
 import static extension com.minres.coredsl.util.ModelExtensions.*
+import com.minres.coredsl.coreDsl.IndexAccessExpression
 
 class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
 // Possible references:
@@ -113,6 +114,9 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
 			MemberAccessExpression: {
 				val declarator = expression.declarator;
 				return declarator?.type;
+			}
+			IndexAccessExpression: {
+				return findTypeSpecifier(expression.target);
 			}
 			FunctionCallExpression: {
 				val function = expression.target.castOrNull(FunctionDefinition);
@@ -215,7 +219,6 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
 		.takeWhile[it !== child] //
 		.filter(DeclarationStatement) //
 		.flatMap[it.declaration.declarators];
-		// TODO make sure enum members can't reference themselves
 		val enumMembers = context.typeDeclarations.filter(EnumTypeDeclaration).flatMap[it.members];
 		return Scopes.scopeFor(declarations + enumMembers + context.functions, getInheritedScope(context));
 	}

--- a/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/scoping/CoreDslScopeProvider.xtend
@@ -179,6 +179,7 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
 	}
 
 	def private static dispatch IScope getNamedEntityScope(Declaration context, EObject child) {
+		if(child == context.type) return getParentNamedEntityScope(context);
 		return Scopes.scopeFor(context.declarators.takeWhile[it !== child], getParentNamedEntityScope(context));
 	}
 
@@ -214,6 +215,7 @@ class CoreDslScopeProvider extends AbstractCoreDslScopeProvider {
 		.takeWhile[it !== child] //
 		.filter(DeclarationStatement) //
 		.flatMap[it.declaration.declarators];
+		// TODO make sure enum members can't reference themselves
 		val enumMembers = context.typeDeclarations.filter(EnumTypeDeclaration).flatMap[it.members];
 		return Scopes.scopeFor(declarations + enumMembers + context.functions, getInheritedScope(context));
 	}

--- a/com.minres.coredsl/src/com/minres/coredsl/type/CompositeType.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/type/CompositeType.xtend
@@ -17,6 +17,7 @@ class CompositeType extends CoreDslType {
 		this.fields = fields;
 	}
 
+	override isCompositeType() { return true; }
 	override isStructType() { return declaration instanceof StructTypeDeclaration; }
 	override isUnionType() { return declaration instanceof UnionTypeDeclaration; }
 	

--- a/com.minres.coredsl/src/com/minres/coredsl/type/CoreDslType.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/type/CoreDslType.xtend
@@ -8,6 +8,7 @@ abstract class CoreDslType {
 	
 	def isFunctionType() { return false; }
 	def isPrimitiveType() { return false; }
+	def isCompositeType() { return false; }
 	def isScalarType() { return false; } // primitive and pointer
 	def isIntegerType() { return false; }
 	def isFloatType() { return false; }

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
@@ -97,6 +97,7 @@ class IssueCodes {
 	public static val ShiftAlwaysZero = _prefix + 'ShiftAlwaysZero';
 	public static val UnknownIntrinsicFunction = _prefix + 'UnknownIntrinsicFunction';
 	public static val InvalidIntrinsicFunction = _prefix + 'InvalidIntrinsicFunction';
+	public static val InvalidMemberAccessTarget = _prefix + 'InvalidMemberAccessTarget';
 	public static val SizeOfNotExact = _prefix + 'SizeOfNotExact';
 	public static val IndexOutOfRange = _prefix + 'IndexOutOfRange';
 	public static val IncompleteType = _prefix + 'IncompleteType';

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
@@ -5,6 +5,7 @@ class IssueCodes {
 	}
 
 	public static val SyntaxError = 'org.eclipse.xtext.diagnostics.Diagnostic.Syntax';
+	public static val LinkingError = 'org.eclipse.xtext.diagnostics.Diagnostic.Linking';
 
 	public static val _prefix = "com.minres.coredsl."
 


### PR DESCRIPTION
This PR fixes a bunch of minor issues with the scope resolution logic and related error reporting.

As a small bonus, it also includes preliminary support for bitwise operators in constant expressions for #97.