### PR TITLE
Suppress some type errors during partial analysis

### DIFF
--- a/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
@@ -81,6 +81,7 @@ class IssueCodes {
 	public static val StrayControlFlowStatement = _prefix + 'StrayControlFlowStatement';
 	
 	// expression issues
+	public static val ValidConstantAssignment = _prefix + 'ValidConstantAssignment';
 	public static val InvalidAssignmentTarget = _prefix + 'InvalidAssignmentTarget';
 	public static val InvalidAssignmentType = _prefix + 'InvalidAssignmentType';
 	public static val InvalidOperationType = _prefix + 'InvalidOperationType';


### PR DESCRIPTION
- Suppresses `com.minres.coredsl.NonScalarCondition` for error types
- Suppresses `com.minres.coredsl.InvalidCast` for signedness casts on error types
- Allows assignments where the target has an integer type and the right hand side is a constant expression whose value fits in said type (effectively closes #75)

Please let me know if you come across more of these instances where errors are reported in *instruction sets* (aka. during partial analysis) due to type information not being fully available.