### PR TITLE
Spawn statement

### DIFF
--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/analysis/CoreDslStatementTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/analysis/CoreDslStatementTest.xtend
@@ -493,4 +493,119 @@ class CoreDslStatementTest {
 		.expectError(IssueCodes.ReturnTypeNotConvertible, 14)
 		.run();
 	}
+
+	@Test
+	def void spawnStatement() {
+		'''
+			TEST {
+				encoding: 0;
+				behavior: spawn;
+			}
+		'''
+		.testInstruction()
+		.run();
+		
+		'''
+			TEST {
+				encoding: 0;
+				behavior: {
+					spawn {}
+				}
+			}
+		'''
+		.testInstruction()
+		.run();
+		
+		'''
+			TEST {
+				encoding: 0;
+				behavior: {
+					{};
+					spawn;
+				}
+			}
+		'''
+		.testInstruction()
+		.run();
+		
+		'''
+			TEST {
+				encoding: 0;
+				behavior: spawn {
+					unsigned<1> x = 2;
+				}
+			}
+		'''
+		.testInstruction()
+		.expectError(IssueCodes.InvalidAssignmentType, 4)
+		.run();
+		
+		'''
+			TEST {
+				encoding: 0;
+				behavior: {
+					spawn;
+					spawn;
+				}
+			}
+		'''
+		.testInstruction()
+		.expectError(IssueCodes.InvalidSpawnStatementPlacement, 4)
+		.run();
+		
+		'''
+			TEST {
+				encoding: 0;
+				behavior: {
+					{
+						spawn;
+					}
+				}
+			}
+		'''
+		.testInstruction()
+		.expectError(IssueCodes.InvalidSpawnStatementPlacement, 5)
+		.run();
+		
+		'''
+			TEST {
+				encoding: 0;
+				behavior: spawn spawn;
+			}
+		'''
+		.testInstruction()
+		.expectError(IssueCodes.InvalidSpawnStatementPlacement, 3)
+		.run();
+		
+		'''
+			Core X {
+				always {
+					TEST {
+						spawn;
+					}
+				}
+			}
+		'''
+		.testProgram()
+		.expectError(IssueCodes.InvalidSpawnStatementPlacement, 4)
+		.run();
+		
+		'''
+			void test() {
+				spawn;
+			}
+		'''
+		.testFunction()
+		.expectError(IssueCodes.InvalidSpawnStatementPlacement, 2)
+		.run();
+		
+		'''
+			void test() {
+				spawn;
+			}
+		'''
+		.testFunction()
+		.expectError(IssueCodes.InvalidSpawnStatementPlacement, 2)
+		.run();
+	}
 }

--- a/com.minres.coredsl.tests/src/com/minres/coredsl/tests/analysis/CoreDslStatementTest.xtend
+++ b/com.minres.coredsl.tests/src/com/minres/coredsl/tests/analysis/CoreDslStatementTest.xtend
@@ -423,6 +423,24 @@ class CoreDslStatementTest {
 		'''
 		.testStatements()
 		.run();
+		
+		'''
+			do {
+				break;
+				continue;
+			} while(0);
+		'''
+		.testStatements()
+		.run();
+		
+		'''
+			for(;;) {
+				break;
+				continue;
+			}
+		'''
+		.testStatements()
+		.run();
 	}
 
 	@Test
@@ -453,19 +471,19 @@ class CoreDslStatementTest {
 		.run();
 		
 		'''
-			void test() {
+			void test1() {
 				return;
 			}
 			
-			int test() {
+			int test2() {
 				return;
 			}
 			
-			void test() {
+			void test3() {
 				return 0;
 			}
 			
-			char test() {
+			char test4() {
 				return 128;
 			}
 		'''

--- a/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
+++ b/com.minres.coredsl/src/com/minres/coredsl/CoreDsl.xtext
@@ -63,7 +63,7 @@ Statement:
 	| LoopStatement;
 
 EmptyStatement: {EmptyStatement} ';';
-SpawnStatement: 'spawn' body=Statement;
+SpawnStatement: t_spawn='spawn' body=Statement;
 CompoundStatement: {CompoundStatement} t_openingBrace='{' statements+=Statement* t_closingBrace='}';
 ExpressionStatement: expression=AssignmentExpression ';';
 DeclarationStatement: declaration=MultiInitDeclaration ';';

--- a/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
+++ b/com.minres.coredsl/src/com/minres/coredsl/validation/IssueCodes.xtend
@@ -79,6 +79,7 @@ class IssueCodes {
 	public static val SwitchDuplicateCaseSection = _prefix + 'SwitchDuplicateCaseSection';
 	public static val SwitchCaseConditionOutOfRange = _prefix + 'SwitchCaseConditionOutOfRange';
 	public static val StrayControlFlowStatement = _prefix + 'StrayControlFlowStatement';
+	public static val InvalidSpawnStatementPlacement = _prefix + 'InvalidSpawnStatementPlacement';
 	
 	// expression issues
 	public static val ValidConstantAssignment = _prefix + 'ValidConstantAssignment';


### PR DESCRIPTION
Adds validation for the placement of spawn statements and appropriate test cases.
As discussed previously, the analyzer does not check anything related to the execution semantics.